### PR TITLE
Chart reformat for pebble classic

### DIFF
--- a/src/xdrip.c
+++ b/src/xdrip.c
@@ -2167,9 +2167,9 @@ void window_load_cgm(Window *window_cgm)
 #ifdef DEBUG_LEVEL
 	APP_LOG(APP_LOG_LEVEL_INFO, "Creating Upper and Lower face panels");
 #endif
-	upper_face_layer = bitmap_layer_create(GRect(0,0,144,83));
+	upper_face_layer = bitmap_layer_create(GRect(0,0,144,88));
 	bitmap_layer_set_background_color(upper_face_layer, GColorWhite);
-	lower_face_layer = bitmap_layer_create(GRect(0,84,144,165));
+	lower_face_layer = bitmap_layer_create(GRect(0,89,144,165));
 #ifdef PBL_COLOR
 	bitmap_layer_set_background_color(lower_face_layer, GColorDukeBlue);
 #else

--- a/src/xdrip.c
+++ b/src/xdrip.c
@@ -2167,9 +2167,21 @@ void window_load_cgm(Window *window_cgm)
 #ifdef DEBUG_LEVEL
 	APP_LOG(APP_LOG_LEVEL_INFO, "Creating Upper and Lower face panels");
 #endif
+
+#ifdef PBL_PLATFORM_APLITE
 	upper_face_layer = bitmap_layer_create(GRect(0,0,144,88));
+#else
+	upper_face_layer = bitmap_layer_create(GRect(0,0,144,83));
+#endif
+
 	bitmap_layer_set_background_color(upper_face_layer, GColorWhite);
+
+#ifdef PBL_PLATFORM_APLITE
 	lower_face_layer = bitmap_layer_create(GRect(0,89,144,165));
+#else
+	lower_face_layer = bitmap_layer_create(GRect(0,84,144,165));
+#endif
+
 #ifdef PBL_COLOR
 	bitmap_layer_set_background_color(lower_face_layer, GColorDukeBlue);
 #else

--- a/src/xdrip.c
+++ b/src/xdrip.c
@@ -2300,7 +2300,7 @@ void window_load_cgm(Window *window_cgm)
 	text_layer_set_text_color(time_watch_layer, GColorWhite);
 	text_layer_set_background_color(time_watch_layer, GColorClear);
 #else
-	time_watch_layer = text_layer_create(GRect(0, 82, 143, 44));
+	time_watch_layer = text_layer_create(GRect(0, 84, 143, 44));
 	text_layer_set_text_color(time_watch_layer, GColorWhite);
 	text_layer_set_background_color(time_watch_layer, GColorClear);
 #endif
@@ -2317,7 +2317,7 @@ void window_load_cgm(Window *window_cgm)
 	text_layer_set_text_color(date_app_layer, GColorWhite);
 	text_layer_set_background_color(date_app_layer, GColorClear);
 #else
-	date_app_layer = text_layer_create(GRect(0, 120, 143, 29));
+	date_app_layer = text_layer_create(GRect(0, 122, 143, 29));
 	text_layer_set_text_color(date_app_layer, GColorWhite);
 	text_layer_set_background_color(date_app_layer, GColorClear);
 #endif

--- a/src/xdrip.c
+++ b/src/xdrip.c
@@ -2312,7 +2312,13 @@ void window_load_cgm(Window *window_cgm)
 	text_layer_set_text_color(time_watch_layer, GColorWhite);
 	text_layer_set_background_color(time_watch_layer, GColorClear);
 #else
-	time_watch_layer = text_layer_create(GRect(0, 84, 143, 44));
+
+	#ifdef PBL_PLATFORM_APLITE
+		time_watch_layer = text_layer_create(GRect(0, 84, 143, 44));
+	#else
+		time_watch_layer = text_layer_create(GRect(0, 82, 143, 44));
+	#endif
+
 	text_layer_set_text_color(time_watch_layer, GColorWhite);
 	text_layer_set_background_color(time_watch_layer, GColorClear);
 #endif
@@ -2329,7 +2335,13 @@ void window_load_cgm(Window *window_cgm)
 	text_layer_set_text_color(date_app_layer, GColorWhite);
 	text_layer_set_background_color(date_app_layer, GColorClear);
 #else
-	date_app_layer = text_layer_create(GRect(0, 122, 143, 29));
+	
+	#ifdef PBL_PLATFORM_APLITE
+		date_app_layer = text_layer_create(GRect(0, 122, 143, 29));
+	#else
+		date_app_layer = text_layer_create(GRect(0, 120, 143, 29));
+	#endif
+	
 	text_layer_set_text_color(date_app_layer, GColorWhite);
 	text_layer_set_background_color(date_app_layer, GColorClear);
 #endif


### PR DESCRIPTION
On the pebble classic, the chart got xor'd into the lower dark layer. For a 1-hour timeframe this is 
still visible (see picture) but for longer timeframes not. Furthermore happens at the critical low level.
![img_20160816_055806](https://cloud.githubusercontent.com/assets/9692866/17700863/c83a422a-63c7-11e6-845c-cd3d556ccb32.jpg)

Just for APLITE (classic and classic steel) I moved the time and date a tiny bit and reduced the black background:
![img_20160816_132638](https://cloud.githubusercontent.com/assets/9692866/17700911/ff701670-63c7-11e6-8102-54aaa20528fc.jpg)
