### PR TITLE
Reverted DEBUG check due to it crashing on the PNG decoder on older watches

### DIFF
--- a/src/c/debug.h
+++ b/src/c/debug.h
@@ -17,9 +17,10 @@
 */
 
 // guard againast debug in release, -DPBL_DEBUG is added to debug builds
-#if !defined(PBL_DEBUG)
-#undef DEBUG_LEVEL
-#endif
+// disabled due to running with --debug crashes PNG decoding
+/* #if !defined(PBL_DEBUG) */
+/* #undef DEBUG_LEVEL */
+/* #endif */
 
 /**
  * prevent aplite from not building in trace logging


### PR DESCRIPTION
The trend image will always crash if build with --debug on the 4.4.3 firmware. This is due to some png decoding bug, this bug can be mitigated by introducing a major delay (my guess is some scheduling is going on somewhere) but it results in no trend image and without the delay a hard crash (due to null pointers and likely some race condition).

This does not happen in the normal builds (without --debug) thus removing the --debug option for displaying debug text.