### PR TITLE
Framework structs for communication and trend image generation on device

### DIFF
--- a/src/c/api/communication.c
+++ b/src/c/api/communication.c
@@ -1,0 +1,52 @@
+#include "communication.h"
+#include "../xdrip.h"
+#include "../debug.h"
+#include <pebble.h>
+
+#define CM "COMM FW: "
+
+comm_callback *cb = NULL;
+
+void comm_init(comm_callback *callbacks) {
+    cb = callbacks;
+}
+
+void comm_handle(Tuple *data) {
+    uint32_t key = data->key;
+    DEBUG(CM "Key: %d", key);
+
+    if (cb == NULL) {
+        WARNING(CM "Cannot perform anu actions, no callback registered");
+        return;
+    }
+
+    switch (key) {
+        case FRAMEWORK_HIGHLIMIT:
+            TRACE(CM "High limit");
+            if (cb->high_limit) cb->high_limit(data->value->uint16);
+            break;
+        case FRAMEWORK_LOWLIMIT:
+            TRACE(CM "Low  limit");
+            if (cb->low_limit) cb->low_limit(data->value->uint16);
+            break;
+        case FRAMEWORK_SLOPEVAL:
+            TRACE(CM "SLope icon value");
+            if (cb->slopeval != NULL) cb->slopeval(data->value->uint8);
+            break;
+        case FRAMEWORK_PHONEBAT:
+            TRACE(CM "Phone battery level");
+            if (cb->phonebat != NULL) cb->phonebat(data->value->uint8);
+            break;
+        case FRAMEWORK_VIBE:
+            TRACE(CM "Vibrate");
+            if (cb->vibe != NULL) cb->vibe(data->value->uint8);
+            break;
+        case FRAMEWORK_BGL_DELTA:
+            TRACE(CM "Delta value");
+            if (cb->bgl_delta != NULL) cb->bgl_delta((comm_bgl_delta) { .raw = data->value->uint16 });
+            break;
+        default:
+            WARNING(CM "id %ld not handled by communications framework", key);
+            break;
+    }
+}

--- a/src/c/api/communication.c
+++ b/src/c/api/communication.c
@@ -23,11 +23,11 @@ void comm_handle(Tuple *data) {
     switch (key) {
         case FRAMEWORK_HIGHLIMIT:
             TRACE(CM "High limit");
-            if (cb->high_limit) cb->high_limit(data->value->uint16);
+            if (cb->high_limit) cb->high_limit((comm_high_limit) { .raw = data->value->uint32 });
             break;
         case FRAMEWORK_LOWLIMIT:
             TRACE(CM "Low  limit");
-            if (cb->low_limit) cb->low_limit(data->value->uint16);
+            if (cb->low_limit) cb->low_limit((comm_low_limit) { .raw = data->value->uint32 });
             break;
         case FRAMEWORK_SLOPEVAL:
             TRACE(CM "SLope icon value");
@@ -45,8 +45,56 @@ void comm_handle(Tuple *data) {
             TRACE(CM "Delta value");
             if (cb->bgl_delta != NULL) cb->bgl_delta((comm_bgl_delta) { .raw = data->value->uint16 });
             break;
+        case FRAMEWORK_BGL_VALUE:
+            TRACE(CM "Update value");
+            comm_bgl_data *value = (comm_bgl_data *) data->value->data;
+            if (cb->bgl_data != NULL) cb->bgl_data(value);
+            if (cb->bgl_timestamp != NULL) cb->bgl_timestamp(value->timestamp);
+            if (cb->bgl_value != NULL) cb->bgl_value(value->bgl);
+            break;
+        case FRAMEWORK_BGL_SERIES:
+            TRACE(CM "BGL Data stream");
+            comm_bgl_series *series = (comm_bgl_series *) data->value->data;
+            TRACE(CM "Since %d", series->timestamp);
+            if (cb->bgl_series != NULL) cb->bgl_series(series);
+            if (cb->bgl_timestamp != NULL) cb->bgl_timestamp(series->timestamp);
+            if (cb->bgl_value != NULL) cb->bgl_value(series->bgl_values[series->length - 1]);
+            break;
         default:
             WARNING(CM "id %ld not handled by communications framework", key);
             break;
     }
 }
+
+            /* case CGM_TREND_BEGIN_NEW_KEY: */
+            /*     TRACE("New Trend data begin"); */
+			/* 	expected_trend_buffer_length = data->value->uint16; */
+			/* 	LOG("TREND_BEGIN; About to receive Trend data of %i size.", expected_trend_buffer_length); */
+            /*     t_config.bgl.size = expected_trend_buffer_length; */
+            /*     break; */
+            /* case CGM_TREND_DATA_NEW_KEY: */
+            /*     TRACE("New Trend data blob of size %d", data->length >> 1); */
+            /*     data16 = (int16_t *) data->value->data; */
+            /*     for (int i = 0; i < data->length >> 1; i++) { */
+            /*         #<{(| TRACE("TREND DATA: %d", *data16); |)}># */
+            /*         t_config.bgl.values[t_config.bgl.index % (t_config.bgl.size)] = *data16++; */
+            /*         t_config.bgl.index++; */
+            /*         t_config.bgl.index = t_config.bgl.index % (t_config.bgl.size); */
+            /*     } */
+            /*     #<{(| if (data->length < 100 && t_config.bgl.initialized == 0) t_config.bgl.initialized = 1; |)}># */
+            /*     break; */
+            /* case CGM_TREND_END_NEW_KEY: */
+            /*     TRACE("New Trend data end"); */
+            /*     t_config.bgl.initialized = 1; */
+            /*     // draw trend */
+            /*     trend_draw(); */
+            /*     break; */
+            /* case CGM_TREND_UPDATE_NEW_KEY: */
+            /*     TRACE("New Trend data update: %hd", data->value->int16); */
+            /*     data16 = (int16_t *) data->value->data; */
+            /*     t_config.bgl.values[t_config.bgl.index % (t_config.bgl.size - 1)] = *data16; */
+            /*     t_config.bgl.index++; */
+            /*     t_config.bgl.index = t_config.bgl.index % (t_config.bgl.size - 1); */
+            /*     trend_draw(); */
+            /*     break; */
+            /*  */

--- a/src/c/api/communication.h
+++ b/src/c/api/communication.h
@@ -2,6 +2,21 @@
 #define __COMMUNICATION_H__
 
 #include <stdint.h>
+#include <pebble.h>
+
+/**
+ * Message codes for framework communication
+ */
+#define FRAMEWORK_HEARTBEAT         2000
+#define FRAMEWORK_BGL_DELTA         2001
+#define FRAMEWORK_BGL_VALUE         2002
+#define FRAMEWORK_PHONEBAT          2003
+#define FRAMEWORK_MESSAGE           2004
+#define FRAMEWORK_HIGHLIMIT         2005
+#define FRAMEWORK_LOWLIMIT          2006
+#define FRAMEWORK_VIBE              2007
+#define FRAMEWORK_SLOPEVAL          2008 
+#define FRAMEWORK_BGL_SERIES        2009
 
 /**
  * Struct definitions for communication
@@ -30,26 +45,27 @@ typedef union comm_trend_size_t {
 
 /**
  * Heartbeat data request indicator
- * Note: endianess is BE, LE on chip
+ * Note: transport endianess is BE, LE on chip
  */
 typedef union comm_heartbeat_t {
     struct {
         // B2-3
         uint32_t : 16;                  // RFU
         // B1
-        uint32_t send_pump_state : 1;   // Send pump state
-        uint32_t send_pump_battery : 1; // Send battery state
-        uint32_t send_delta_value : 1;  // Send delta value
+        uint32_t : 3;
         uint32_t send_slope_arrow : 1;  // Send slope arrow value
-        uint32_t : 4;
+        uint32_t send_delta_value : 1;  // Send delta value
+        uint32_t send_pump_battery : 1; // Send battery state
+        uint32_t send_phone_battery : 1; // 
+        uint32_t send_pump_state : 1;   // Send pump state
         // B0
-        uint32_t colour : 1;            // Is pebble colour capable
-        uint32_t time_series : 1;       // Send time series (1) or PNG (0)
-        uint32_t time_period : 2;       // Time period (0b00 = 1h, 0b01 = 2h, 0b10 = 3h, 0b11 = 4h)
-        uint32_t height_limit : 1;      // Add height line or send height line value
-        uint32_t low_limit : 1;         // Add low limit line or send low limit line value
-        uint32_t small_dots : 1;        // Use smal dots (1) or larger (0), PNG only
         uint32_t send_iob : 1;          // Send IOB data
+        uint32_t small_dots : 1;        // Use smal dots (1) or larger (0), PNG only
+        uint32_t low_limit : 1;         // Add low limit line or send low limit line value
+        uint32_t high_limit : 1;      // Add height line or send height line value
+        uint32_t time_period : 2;       // Time period (0b00 = 1h, 0b01 = 2h, 0b10 = 3h, 0b11 = 4h)
+        uint32_t time_series : 1;       // Send time series (1) or PNG (0)
+        uint32_t colour : 1;            // Is pebble colour capable
     };
     uint32_t    raw;
 } comm_heartbeat;
@@ -65,8 +81,17 @@ typedef struct comm_bgl_value_t {
 typedef struct comm_bgl_data_t {
     uint32_t        timestamp;      // timestamp of bgl value
     comm_bgl_value  bgl;
-    uint8_t         delta;
 } comm_bgl_data;
+
+typedef union  comm_bgl_delta_t {
+    struct {
+        uint16_t        value : 13;
+        uint16_t        is_neg : 1;
+        uint16_t        display_units : 1;
+        uint16_t        is_mmol : 1;
+    };
+    uint16_t raw;
+} comm_bgl_delta;
 
 typedef struct comm_bgl_series_t {
     uint32_t        timestamp;      // current timestamp of last reading
@@ -83,9 +108,26 @@ typedef struct comm_message_t {
 
 typedef uint16_t comm_high_limit;
 typedef uint16_t comm_low_limit;
-typedef uint8_t vibe;
+typedef uint8_t comm_vibe;
 typedef uint8_t comm_slopeval;
 
 #pragma pack()
 
+/*
+ * Callback struct
+ */
+typedef struct comm_callback_t {
+    void (*phonebat)(comm_phonebat value);
+    void (*low_limit)(comm_low_limit value);
+    void (*high_limit)(comm_high_limit value);
+    void (*slopeval)(comm_slopeval value);
+    void (*vibe)(comm_vibe value);
+    void (*bgl_data)(comm_bgl_data value);
+    void (*bgl_series)(comm_bgl_series value);
+    void (*bgl_delta)(comm_bgl_delta value);
+} comm_callback;
+
+
+void comm_init(comm_callback *cb);
+void comm_handle(Tuple *data);
 #endif // __COMMUNICATION_H__

--- a/src/c/api/communication.h
+++ b/src/c/api/communication.h
@@ -43,6 +43,10 @@ typedef union comm_trend_size_t {
     uint32_t raw;                       // Data Blob
 } comm_trend_size;
 
+typedef struct comm_trend_request_t {
+    uint32_t from;
+} comm_trend_request;
+
 /**
  * Heartbeat data request indicator
  * Note: transport endianess is BE, LE on chip
@@ -74,8 +78,8 @@ typedef union comm_heartbeat_t {
  * measurement range is 40-400, 9 bits is enough
  */
 typedef struct comm_bgl_value_t {
-    uint16_t        is_mmol : 1;    // display value as mmol/l
     uint16_t        value : 15;     // bgl in mg/dl
+    uint16_t        is_mmol : 1;    // display value as mmol/l
 } comm_bgl_value;
 
 typedef struct comm_bgl_data_t {
@@ -106,8 +110,20 @@ typedef struct comm_message_t {
     char    message[];
 } comm_message;
 
-typedef uint16_t comm_high_limit;
-typedef uint16_t comm_low_limit;
+typedef union  {
+    struct {
+        uint16_t high_line;
+        uint16_t high_limit;
+    };
+    uint32_t raw;
+} comm_high_limit;
+typedef union {
+    struct {
+        uint16_t low_line;
+        uint16_t low_limit;
+    };
+    uint32_t raw;
+} comm_low_limit;
 typedef uint8_t comm_vibe;
 typedef uint8_t comm_slopeval;
 
@@ -122,9 +138,11 @@ typedef struct comm_callback_t {
     void (*high_limit)(comm_high_limit value);
     void (*slopeval)(comm_slopeval value);
     void (*vibe)(comm_vibe value);
-    void (*bgl_data)(comm_bgl_data value);
-    void (*bgl_series)(comm_bgl_series value);
+    void (*bgl_data)(comm_bgl_data *value);
+    void (*bgl_series)(comm_bgl_series *value);
     void (*bgl_delta)(comm_bgl_delta value);
+    void (*bgl_value)(comm_bgl_value value);
+    void (*bgl_timestamp)(uint32_t timestamp);
 } comm_callback;
 
 

--- a/src/c/api/communication.h
+++ b/src/c/api/communication.h
@@ -1,0 +1,91 @@
+#ifndef __COMMUNICATION_H__
+#define __COMMUNICATION_H__
+
+#include <stdint.h>
+
+/**
+ * Struct definitions for communication
+ */
+#pragma pack(1)
+/**
+ * "old" trend size, note: endianess is BE, so some
+ * conversion has to be done
+ */
+typedef union comm_trend_size_t {
+    struct {
+        union {
+            struct {
+                uint32_t height : 8;    // Height value of PNG
+                uint32_t width : 8;     // Width value of PNG
+                uint32_t : 8;
+            };
+            uint32_t size : 24;         // Alternative size
+        };
+        uint32_t rgb8 : 1;              // Send RGB8 png
+        uint32_t data_only : 1;         // Send trend series instead of PNG
+        uint32_t : 6;                   // RFU
+    };
+    uint32_t raw;                       // Data Blob
+} comm_trend_size;
+
+/**
+ * Heartbeat data request indicator
+ * Note: endianess is BE, LE on chip
+ */
+typedef union comm_heartbeat_t {
+    struct {
+        // B2-3
+        uint32_t : 16;                  // RFU
+        // B1
+        uint32_t send_pump_state : 1;   // Send pump state
+        uint32_t send_pump_battery : 1; // Send battery state
+        uint32_t send_delta_value : 1;  // Send delta value
+        uint32_t send_slope_arrow : 1;  // Send slope arrow value
+        uint32_t : 4;
+        // B0
+        uint32_t colour : 1;            // Is pebble colour capable
+        uint32_t time_series : 1;       // Send time series (1) or PNG (0)
+        uint32_t time_period : 2;       // Time period (0b00 = 1h, 0b01 = 2h, 0b10 = 3h, 0b11 = 4h)
+        uint32_t height_limit : 1;      // Add height line or send height line value
+        uint32_t low_limit : 1;         // Add low limit line or send low limit line value
+        uint32_t small_dots : 1;        // Use smal dots (1) or larger (0), PNG only
+        uint32_t send_iob : 1;          // Send IOB data
+    };
+    uint32_t    raw;
+} comm_heartbeat;
+
+/**
+ * measurement range is 40-400, 9 bits is enough
+ */
+typedef struct comm_bgl_value_t {
+    uint16_t        is_mmol : 1;    // display value as mmol/l
+    uint16_t        value : 15;     // bgl in mg/dl
+} comm_bgl_value;
+
+typedef struct comm_bgl_data_t {
+    uint32_t        timestamp;      // timestamp of bgl value
+    comm_bgl_value  bgl;
+    uint8_t         delta;
+} comm_bgl_data;
+
+typedef struct comm_bgl_series_t {
+    uint32_t        timestamp;      // current timestamp of last reading
+    uint16_t        length;         // values to receive
+    comm_bgl_value  bgl_values[];   // open ended array of values
+} comm_bgl_series;
+
+typedef uint8_t comm_phonebat;
+
+typedef struct comm_message_t {
+    uint8_t length;
+    char    message[];
+} comm_message;
+
+typedef uint16_t comm_high_limit;
+typedef uint16_t comm_low_limit;
+typedef uint8_t vibe;
+typedef uint8_t comm_slopeval;
+
+#pragma pack()
+
+#endif // __COMMUNICATION_H__

--- a/src/c/api/trend.c
+++ b/src/c/api/trend.c
@@ -1,0 +1,279 @@
+/**
+ *
+ * Use as is. No guarantees.
+ */
+#include <pebble.h>
+
+#include "../xdrip.h"
+#include "../debug.h"
+#include "communication.h"
+
+#include "trend.h"
+
+/**
+ * File contains functions for drawing the trend image from a list of BGL values vs time
+ *
+ * Options/constraints:
+ * - Draw only lates <n>, e.g. if you have 500 items draw only <pixel width of draw box>
+ * - Draw all and aliase
+ * - Color/gray(scale)
+ * - Enable/disable high/low line
+ * - Set colors
+ * - Set line colors
+ */
+
+static void trend_layer_callback(Layer *layer, GContext *ctx);
+
+trend_config *config = NULL;
+
+void trend_set_config(trend_config *cfg) {
+    config = cfg;
+    if (cfg == NULL) {
+        LOG("NULL configuration! Graph is disabled");
+        return;
+    }
+    TRACE(TREND_LOG "Setting callback");
+    layer_set_update_proc((Layer *) config->layer, trend_layer_callback);
+}
+
+
+static inline void draw_bgl_point(trend_bgl_value value, int16_t x, trend_config *config, GRect bounds, GContext *ctx) {
+    /**
+     * Since the trend image is just a graph, we do not need to know the 
+     * actual type of data
+     */
+
+    if (value < config->bgl_low_limit || value > config->bgl_high_limit) return;
+
+    GColor color = config->good_color;
+
+    if (value > config->bgl_high) color = config->high_color;
+    else if (value > config->bgl_average) color = config->average_color;
+    else if (value < config->bgl_low) color = config->low_color;
+
+    graphics_context_set_stroke_color(ctx, color);
+    
+    GPoint point = {x, BGL_TO_Y(value, config, bounds)};
+
+    graphics_draw_circle(ctx, point, 0);
+
+}
+
+static inline void draw_bgl_line(trend_bgl_value value, trend_bgl_value value2, int16_t x1, int16_t x2, trend_config *config, GRect bounds, GContext *ctx) {
+    /**
+     * Since the trend image is just a graph, we do not need to know the 
+     * actual type of data
+     */
+
+    // ignore zero/extreme values, single high value will stay to allow line into the graph
+    if (value < config->bgl_low_limit || value2 < config->bgl_low_limit) return;
+    if (value2 > config->bgl_high_limit && value2 > config->bgl_high_limit) return;
+
+    GColor color = config->good_color;
+
+    if (value > config->bgl_high) color = config->high_color;
+    else if (value > config->bgl_average) color = config->average_color;
+    else if (value < config->bgl_low) color = config->low_color;
+
+    color = COLOR_FALLBACK(color, GColorWhite); // b/w compatability
+
+    graphics_context_set_stroke_color(ctx, color);
+    
+    GPoint point = {x1, BGL_TO_Y(value, config, bounds)};
+    GPoint point2 = {x2, BGL_TO_Y(value2, config, bounds)};
+
+    graphics_draw_line(ctx, point, point2);
+
+}
+
+/**
+ * t is the fractional distance between x0 and x1
+ */
+static inline int16_t lerp(int32_t y0, int32_t y1, uint32_t t) {
+    if (t == 0) return y0;
+    if (t == 1 << 16) return y1;
+    return ((y0 << 16) + (t * (y1 - y0))) >> 16;
+}
+
+static bool draw_trend(trend_config *config, Layer *layer, GContext *ctx) {
+    graphics_context_set_stroke_width(ctx, config->trend_width); // constant
+
+    GRect bounds = layer_get_bounds(layer);
+
+    bool interp = config->style == TREND_STYLE_DOTS ? (bounds.size.w > config->bgl.size) : false; // do not interp on lines 
+    int32_t t = 0;
+    int32_t interval = (config->bgl.size << 16) / bounds.size.w;
+    if (config->style == TREND_STYLE_LINES) interval = ((config->bgl.size - 1) << 16) / bounds.size.w;
+    int index = 0;
+    TRACE(TREND_LOG "Size: %d array %d ", bounds.size.w, config->bgl.size);
+    TRACE(TREND_LOG "Interp settings: [%d] :: %d", interp, interval);
+
+    if (config->style == TREND_STYLE_DOTS) {
+        // simplified
+        TRACE(TREND_LOG "Doing interpolation"); 
+        for (int i = 0; i < bounds.size.w; i++) {
+            if (interp) {
+                int16_t y0 = lerp(
+                        config->bgl.values[(config->bgl.index + index) % (config->bgl.size - 1)], 
+                        config->bgl.values[(config->bgl.index + index + 1) % (config->bgl.size - 1)], 
+                        t);
+                t += interval;
+                if (t >= (1 << 16)) index++;
+                draw_bgl_point(y0, i, config, bounds, ctx);
+                t %= 1 << 16;
+            } else {
+                draw_bgl_point(config->bgl.values[(config->bgl.index + i) % (config->bgl.size - 1)], i, config, bounds, ctx); 
+            }
+        }
+    } else if (config->style == TREND_STYLE_LINES) {
+        if (interp) {
+            for (int i = 0; i < bounds.size.w; i++) {
+                if (interp) {
+                    int16_t y0 = lerp(
+                            config->bgl.values[(config->bgl.index + index) % (config->bgl.size)], 
+                            config->bgl.values[(config->bgl.index + index + 1) % (config->bgl.size)], 
+                            t);
+                    int16_t y1 = lerp(
+                            config->bgl.values[(config->bgl.index + index) % (config->bgl.size)], 
+                            config->bgl.values[(config->bgl.index + index + 1) % (config->bgl.size)], 
+                            t += interval);
+                    /* TRACE(TREND_LOG "Line %d %d %d %d %d %d %d", */
+                    /*         config->bgl.size, config->bgl.index, index, */
+                    /*         y0, y1,  */
+                    /*         config->bgl.values[(config->bgl.index + index) % (config->bgl.size)],  */
+                    /*         config->bgl.values[(config->bgl.index + index + 1) % (config->bgl.size)]); */
+                    draw_bgl_line(y0, y1, i, i+1, config, bounds, ctx);
+                    if (t >= (1 << 16)) {
+                        index++;
+                        t %= 1 << 16;
+                        /* TRACE(TREND_LOG "Index: %hu of %hu, %hu", index, config->bgl.size, t); */
+                    }
+                }
+            }
+        } else {
+            // currently forced path
+            uint32_t t = (bounds.size.w << 16) / (config->bgl.size - 1); 
+            for (uint32_t i = 0, j = 0; i < ((uint32_t) bounds.size.w << 16); i += t, j++) {
+                draw_bgl_line(
+                        config->bgl.values[(config->bgl.index + j) % (config->bgl.size)],
+                        config->bgl.values[(config->bgl.index + j + 1) % (config->bgl.size)],
+                        i >> 16, (i+t) >> 16, config, bounds, ctx); 
+            }
+        }
+    }
+    return true;
+}
+
+static bool draw_trend_lines(trend_config  *config, Layer *layer, GContext *ctx) {
+    // top is 0,0
+    GRect bounds = layer_get_bounds(layer);
+    const int16_t h = BGL_TO_Y(config->bgl_high_line, config, bounds); 
+    const int16_t l = BGL_TO_Y(config->bgl_low_line, config, bounds); 
+    TRACE(TREND_LOG "Draw lines, high: %d, low %d", h, l);
+
+    // drawing
+    graphics_context_set_stroke_width(ctx, config->line_width);
+    int w = 0, s = 0;
+    switch (config->line_style) {
+        default:
+        case TREND_LINE_STYLE_SOLID:
+            graphics_context_set_stroke_color(ctx, COLOR_FALLBACK(config->high_line_color, GColorWhite));
+            graphics_draw_line(ctx, (GPoint) { 0, h }, (GPoint) { bounds.size.w, h});
+            graphics_context_set_stroke_color(ctx, COLOR_FALLBACK(config->low_line_color, GColorWhite));
+            graphics_draw_line(ctx, (GPoint) { 0, l }, (GPoint) { bounds.size.w, l});
+            break;
+        case TREND_LINE_STYLE_DOTTED_SPARSE:
+            s = 1;
+            // fall through
+        case TREND_LINE_STYLE_DOTTED:
+            s += 2;
+            graphics_context_set_stroke_color(ctx, COLOR_FALLBACK(config->high_line_color, GColorWhite));
+            for (int x = 0; x < bounds.size.w; x+=s) {
+                graphics_draw_pixel(ctx, (GPoint) { x, h });
+            }
+            graphics_context_set_stroke_color(ctx, COLOR_FALLBACK(config->low_line_color, GColorWhite));
+            for (int x = 0; x < bounds.size.w; x+=s) {
+                graphics_draw_pixel(ctx, (GPoint) { x, l });
+            }
+            break;
+        case TREND_LINE_STYLE_DASHED_WIDE:
+            s = 5;
+            w = 2;
+            // fall through
+        case TREND_LINE_STYLE_DASHED:
+            s += 5;
+            w += 2;
+            graphics_context_set_stroke_color(ctx, COLOR_FALLBACK(config->high_line_color, GColorWhite));
+            for (int x = 0; x < bounds.size.w; x+=s) {
+                graphics_draw_line(ctx, (GPoint) { x, h }, (GPoint) { x+w, h});
+            }
+            graphics_context_set_stroke_color(ctx, COLOR_FALLBACK(config->low_line_color, GColorWhite));
+            for (int x = 0; x < bounds.size.w; x+=s) {
+                graphics_draw_line(ctx, (GPoint) { x, l }, (GPoint) { x+w, l});
+            }
+            break;
+    }
+    return true;
+}
+
+void trend_layer_callback(Layer *layer, GContext *ctx) {
+    if (config == NULL) {
+        LOG("No trend configuration set, do nothing");
+        return; 
+    }
+
+    TRACE(TREND_LOG "Drawing trend line");
+    draw_trend(config, layer, ctx);
+    TRACE(TREND_LOG "Drawing high/low lines");
+    draw_trend_lines(config, layer, ctx);
+    config->redraw = 0; 
+}
+
+void trend_draw(void) {
+    if (config == NULL) {
+        INFO(TREND_LOG "No trend configuration set, do nothing");
+        return;
+    }
+    DEBUG(TREND_LOG "Marking trend layer dirty");
+    config->redraw = 1;
+    layer_mark_dirty(config->layer);
+}
+
+
+/*
+ * Update functions
+ */
+
+void trend_set_series(comm_bgl_series *values) {
+    TRACE(TREND_LOG "Trend set series"); 
+    if (config == NULL) {
+        INFO("No config set");
+        return;
+    }
+    if (!config->bgl.initialized) {
+        DEBUG("Initializing");
+        config->bgl.size = values->length > PBL_DISPLAY_WIDTH ? PBL_DISPLAY_WIDTH : values->length;
+        config->bgl.index = 0;
+        config->bgl.initialized = 1;
+        memset(config->bgl.values, 0x00, sizeof(config->bgl.values));
+        config->bgl_type = values->bgl_values[0].is_mmol ? BGL_TYPE_MMOL_L : BGL_TYPE_MG_DL;
+    }
+    TRACE("Parsing data: %d", values->length);
+    for (int i = 0; i < values->length && i < PBL_DISPLAY_WIDTH; i++) {
+        TRACE("TREND DATA: %d %d", i, values->bgl_values[i].value);
+        config->bgl.values[config->bgl.index % (config->bgl.size)] = values->bgl_values[i].value;
+        config->bgl.index++;
+        config->bgl.index = config->bgl.index % (config->bgl.size);
+    }
+    trend_draw();
+}
+
+void trend_set_value(comm_bgl_data *value) {
+    TRACE(TREND_LOG "Trend set value");
+    if (config == NULL) return;
+    config->bgl.values[config->bgl.index % (config->bgl.size - 1)] = value->bgl.value;
+    config->bgl.index++;
+    config->bgl.index = config->bgl.index % (config->bgl.size - 1);
+    trend_draw();
+
+}

--- a/src/c/api/trend.c
+++ b/src/c/api/trend.c
@@ -102,8 +102,7 @@ static bool draw_trend(trend_config *config, Layer *layer, GContext *ctx) {
 
     bool interp = config->style == TREND_STYLE_DOTS ? (bounds.size.w > config->bgl.size) : false; // do not interp on lines 
     int32_t t = 0;
-    int32_t interval = (config->bgl.size << 16) / bounds.size.w;
-    if (config->style == TREND_STYLE_LINES) interval = ((config->bgl.size - 1) << 16) / bounds.size.w;
+    int32_t interval = ((config->bgl.size - 1) << 16) / bounds.size.w;
     int index = 0;
     TRACE(TREND_LOG "Size: %d array %d ", bounds.size.w, config->bgl.size);
     TRACE(TREND_LOG "Interp settings: [%d] :: %d", interp, interval);
@@ -114,15 +113,15 @@ static bool draw_trend(trend_config *config, Layer *layer, GContext *ctx) {
         for (int i = 0; i < bounds.size.w; i++) {
             if (interp) {
                 int16_t y0 = lerp(
-                        config->bgl.values[(config->bgl.index + index) % (config->bgl.size - 1)], 
-                        config->bgl.values[(config->bgl.index + index + 1) % (config->bgl.size - 1)], 
+                        config->bgl.values[(config->bgl.index + index) % (config->bgl.size)], 
+                        config->bgl.values[(config->bgl.index + index + 1) % (config->bgl.size)], 
                         t);
                 t += interval;
                 if (t >= (1 << 16)) index++;
                 draw_bgl_point(y0, i, config, bounds, ctx);
                 t %= 1 << 16;
             } else {
-                draw_bgl_point(config->bgl.values[(config->bgl.index + i) % (config->bgl.size - 1)], i, config, bounds, ctx); 
+                draw_bgl_point(config->bgl.values[(config->bgl.index + i) % (config->bgl.size)], i, config, bounds, ctx); 
             }
         }
     } else if (config->style == TREND_STYLE_LINES) {

--- a/src/c/api/trend.h
+++ b/src/c/api/trend.h
@@ -1,0 +1,77 @@
+#ifndef __TREND_H__
+#define __TREND_H__
+
+#include <pebble.h>
+#include "communication.h"
+
+
+#define TREND_LOG "TREND :: "
+
+typedef int16_t trend_bgl_value; 
+
+typedef enum {
+    BGL_TYPE_MMOL_L = 0,
+    BGL_TYPE_MG_DL = 1
+} bgl_type;
+
+typedef enum {
+    TREND_STYLE_DOTS = 0,
+    TREND_STYLE_LINES = 1
+} trend_style;
+
+typedef enum {
+    TREND_LINE_STYLE_SOLID = 0,
+    TREND_LINE_STYLE_DOTTED,
+    TREND_LINE_STYLE_DOTTED_SPARSE,
+    TREND_LINE_STYLE_DASHED,
+    TREND_LINE_STYLE_DASHED_WIDE,
+} trend_line_style;
+
+typedef struct {
+    int8_t  initialized;
+    int16_t size;
+    int16_t index;
+    trend_bgl_value values[PBL_DISPLAY_WIDTH]; // maximum
+} bgl_array;
+
+
+typedef struct {
+    bgl_type    bgl_type;
+    GColor      critical_color;
+    GColor      high_color;
+    GColor      average_color;
+    GColor      good_color;
+    GColor      low_color;
+    GColor      high_line_color;
+    GColor      low_line_color;
+    int8_t      line_width;
+    int8_t      trend_width;
+    int16_t     bgl_low;
+    int16_t     bgl_average;
+    int16_t     bgl_high;
+    int16_t     bgl_high_line;
+    int16_t     bgl_low_line;
+    int16_t     bgl_high_limit;
+    int16_t     bgl_low_limit;
+    Layer       *layer;
+    bgl_array   bgl;
+    trend_style style;
+    trend_line_style line_style;
+    int8_t      redraw;
+} trend_config;
+
+void trend_set_config(trend_config *cfg);
+void trend_draw(void);
+void trend_set_series(comm_bgl_series *values); 
+void trend_set_value(comm_bgl_data *value);
+
+/**
+ * convert bgl to y, respecting limits and bounds
+ */
+#define BGL_TO_Y(bgl, config, bounds) (\
+            bounds.size.h - \
+            ((int32_t) (bounds.size.h * (bgl - config->bgl_low_limit))) /\
+            (config->bgl_high_limit - config->bgl_low_limit)\
+        )
+
+#endif

--- a/src/c/xdrip.c
+++ b/src/c/xdrip.c
@@ -1636,7 +1636,7 @@ static void send_cmd_cgm(void)
     hb.colour = 0;
 #endif
 
-    hb.time_period = 3;
+    hb.time_period = 3; // has no effect as the xdrip value will be used
     hb.time_series = 1;
 
     // trend values

--- a/src/c/xdrip.c
+++ b/src/c/xdrip.c
@@ -2,6 +2,9 @@
 #include "xdrip.h" // set DEBUG_LEVEL in here or on the pebble build command line
 #include "debug.h" // must be included after xdrip.h
 #include "api/communication.h"
+#ifdef ENABLE_TREND_RENDERER
+#include "api/trend.h"
+#endif
 /**
  * Variables
  */
@@ -141,6 +144,31 @@ TextLayer *heart_rate_text_layer = NULL;
 #endif
 #endif
 
+// trend config
+#ifdef ENABLE_TREND_RENDERER
+trend_config t_config = {
+    .bgl_type = BGL_TYPE_MG_DL,
+    .average_color = GColorOrange,
+    .good_color = GColorGreen,
+    .critical_color = GColorFromRGBA(255, 0, 0, 255),
+    .low_color = GColorBlue,
+    .high_color = GColorRed,
+    .high_line_color = (GColor) {.r = 3, .a = 2},
+    .low_line_color = (GColor) {.g = 3, .a = 2},
+    .bgl_average = 126,
+    .bgl_low = 72,
+    .bgl_high = 216,
+    .bgl_high_line = 216,
+    .bgl_low_line = 72,
+    .bgl_high_limit = 270,
+    .bgl_low_limit = 36,
+    .line_width = 2,
+    .trend_width = 4,
+    .style = TREND_STYLE_LINES,
+    .line_style = TREND_LINE_STYLE_DASHED_WIDE,
+};
+#endif
+// comms framework
 #ifdef ENABLE_COMM_FRAMEWORK
 comm_callback comm_callbacks;
 
@@ -150,6 +178,8 @@ void set_low_limit(comm_low_limit value);
 void set_high_limit(comm_high_limit value);
 void set_vibrate(comm_vibe value);
 void set_bgl_delta(comm_bgl_delta value);
+void set_bgl_timestamp(uint32_t timestamp); 
+void set_bgl_value(comm_bgl_value value);
 #endif
 
 /**
@@ -1607,18 +1637,24 @@ static void send_cmd_cgm(void)
     hb.time_series = 1;
 
     // trend values
-    hb.high_limit = 1;
-    hb.low_limit = 1;
+    if (!t_config.bgl.initialized) { 
+        hb.high_limit = 1;
+        hb.low_limit = 1;
+    }
 
     // delta + pump values
     /* hb.send_iob = 1; */
     /* hb.send_pump_state = 1; */
-    hb.send_slope_arrow = 1;
     /* hb.send_pump_battery = 1; */
+    
+    // function is called when BGL times out, send data
+    hb.send_slope_arrow = 1;
     hb.send_delta_value = 1;
+
     if (bottom_right_metric == METRIC_PHONEBATT || bottom_left_metric == METRIC_PHONEBATT) hb.send_phone_battery = 1;
 
 	dict_write_uint32(iter, FRAMEWORK_HEARTBEAT, hb.raw);
+    dict_write_uint32(iter, FRAMEWORK_BGL_VALUE, current_cgm_time); // request update
 #else
 	comm_trend_size trend_size;
 	LOG("send_cmd_cgm called.");
@@ -2786,6 +2822,14 @@ void window_load_cgm(Window *window_cgm)
 #endif
 	load_battlevel();
 
+#ifdef ENABLE_TREND_RENDERER
+    // default config
+    t_config.layer = (Layer *) bg_trend_layer;
+    t_config.bgl.index = 0;
+    t_config.bgl.initialized = 0;
+    trend_set_config(&t_config);
+#endif
+
 //	TRACE("WINDOW LOAD, ABOUT TO CALL APP SYNC INIT");
 	//app_sync_init(&sync_cgm, sync_buffer_cgm, sizeof(sync_buffer_cgm), initial_values_cgm, ARRAY_LENGTH(initial_values_cgm), sync_tuple_changed_callback_cgm, sync_error_callback_cgm, NULL);
 	// init timer to null if needed, and register timer
@@ -2976,6 +3020,10 @@ static void init_cgm(void)
     comm_callbacks.slopeval = set_icon;
     comm_callbacks.vibe = set_vibrate;
     comm_callbacks.bgl_delta = set_bgl_delta;
+    comm_callbacks.bgl_series = trend_set_series;
+    comm_callbacks.bgl_data = trend_set_value;
+    comm_callbacks.bgl_timestamp = set_bgl_timestamp;
+    comm_callbacks.bgl_value = set_bgl_value;
     comm_init(&comm_callbacks);
 #endif
 
@@ -3043,11 +3091,17 @@ void set_icon(comm_slopeval value) {
 }
 
 void set_high_limit(comm_high_limit value) {
-    // do  nothing for now
+    DEBUG("High line limit: %hd %hd", value.high_line, value.high_limit);
+    t_config.bgl_high_line = value.high_line;
+    t_config.bgl_high_limit = value.high_limit;
+    trend_draw();
 }
 
-void set_low_limit(comm_high_limit value) {
-    // do  nothing for now
+void set_low_limit(comm_low_limit value) {
+    DEBUG("Low line limit: %hd %hd", value.low_line, value.low_limit);
+    t_config.bgl_low_line = value.low_line;
+    t_config.bgl_low_limit = value.low_limit;
+    trend_draw();
 }
 
 void set_phone_battery(comm_phonebat value) {
@@ -3084,6 +3138,22 @@ void set_bgl_delta(comm_bgl_delta value) {
 
 void set_vibrate(comm_vibe value) {
     if (!BluetoothAlert) alert_handler_cgm(value);
+}
+
+void set_bgl_timestamp(uint32_t timestamp) {
+    current_cgm_time = timestamp;
+    load_cgmtime();
+}
+
+void set_bgl_value(comm_bgl_value value) {
+    if (value.is_mmol) {
+        int delta_point = MGDL_TO_MMOL_DEC(value.value);
+        int delta = MGDL_TO_MMOL(value.value);
+        snprintf(last_bg, sizeof(last_bg), "%d.%d", delta, delta_point);
+    } else {
+        snprintf(last_bg, sizeof(last_bg), "%d", value.value);
+    }
+    load_bg();
 }
 #endif
 

--- a/src/c/xdrip.c
+++ b/src/c/xdrip.c
@@ -163,8 +163,8 @@ trend_config t_config = {
     .bgl_high_limit = 270,
     .bgl_low_limit = 36,
     .line_width = 2,
-    .trend_width = 4,
-    .style = TREND_STYLE_LINES,
+    .trend_width = 5,
+    .style = TREND_STYLE_DOTS,
     .line_style = TREND_LINE_STYLE_DASHED_WIDE,
 };
 #endif
@@ -1335,6 +1335,9 @@ static void load_cgmtime()
 		* Thanks Tristan for the fix.
 		*/
 		// Leaving this as per Tristan's work.  Should probably be #if defined, to reduce code on older pebbles, but this is easier while it works.
+#ifndef ENABLE_COMM_FRAMEWORK
+        // new framework sends trend/bgl timestamps as UTC
+
 		if (watch_info_get_model() > WATCH_INFO_MODEL_PEBBLE_TIME_2) {
 			//this code should only run on core devices models.  Hopefully this will not change.
 			struct tm *lc_tm = localtime(&time_now);
@@ -1344,7 +1347,7 @@ static void load_cgmtime()
 			// old models can use get_UTC_offset
 			time_now = abs(time_now + get_UTC_offset(localtime(&time_now)));
 		}
-
+#endif
 //		TRACE("load_cgmtime:  CURRENT CGM TIME: %lu", current_cgm_time);
 		LOG("load_cgmtime:  time_now: %lu, current_cgm_time: %lu", time_now, current_cgm_time);
 

--- a/src/c/xdrip.c
+++ b/src/c/xdrip.c
@@ -141,6 +141,17 @@ TextLayer *heart_rate_text_layer = NULL;
 #endif
 #endif
 
+#ifdef ENABLE_COMM_FRAMEWORK
+comm_callback comm_callbacks;
+
+void set_icon(comm_slopeval value);
+void set_phone_battery(comm_phonebat value);
+void set_low_limit(comm_low_limit value);
+void set_high_limit(comm_high_limit value);
+void set_vibrate(comm_vibe value);
+void set_bgl_delta(comm_bgl_delta value);
+#endif
+
 /**
  * predefines
  */
@@ -1565,19 +1576,10 @@ static void load_battlevel()
 // Needs to include configuration values that xDrip can read and respond to.
 static void send_cmd_cgm(void)
 {
-	comm_trend_size trend_size;
-	DictionaryIterator *iter = NULL;
-	LOG("send_cmd_cgm called.");
 	AppMessageResult sendcmd_openerr = APP_MSG_OK;
 	AppMessageResult sendcmd_senderr = APP_MSG_OK;
+	DictionaryIterator *iter = NULL;
 
-    trend_size.raw = 0;
-	//set up the trend size and colour depth to send.  Note: Gabbro requires PNG8/64 colours, so we set the MSbit to true for that platform.
-    trend_size.width = PBL_DISPLAY_WIDTH;
-    trend_size.height = TREND_HEIGHT;
-#ifdef PBL_PLATFORM_GABBRO
-	trend_size.rgb8 = 1; 
-#endif
 	sendcmd_openerr = app_message_outbox_begin(&iter);
 	if(BluetoothAlert)
 	{
@@ -1587,10 +1589,47 @@ static void send_cmd_cgm(void)
 	}
 	if (sendcmd_openerr != APP_MSG_OK)
 	{
-//		LOG("WATCH SENDCMD OPEN ERROR");
 		LOG("send_cmd_cgm: ERR CODE: %i RES: %s", sendcmd_openerr, translate_app_error(sendcmd_openerr));
 		return;
 	}
+#ifdef ENABLE_COMM_FRAMEWORK
+
+    comm_heartbeat hb;
+    hb.raw = 0; // reset
+
+#ifdef PBL_COLOR
+    hb.colour = 1;
+#else 
+    hb.colour = 0;
+#endif
+
+    hb.time_period = 3;
+    hb.time_series = 1;
+
+    // trend values
+    hb.high_limit = 1;
+    hb.low_limit = 1;
+
+    // delta + pump values
+    /* hb.send_iob = 1; */
+    /* hb.send_pump_state = 1; */
+    hb.send_slope_arrow = 1;
+    /* hb.send_pump_battery = 1; */
+    hb.send_delta_value = 1;
+    if (bottom_right_metric == METRIC_PHONEBATT || bottom_left_metric == METRIC_PHONEBATT) hb.send_phone_battery = 1;
+
+	dict_write_uint32(iter, FRAMEWORK_HEARTBEAT, hb.raw);
+#else
+	comm_trend_size trend_size;
+	LOG("send_cmd_cgm called.");
+
+    trend_size.raw = 0;
+	//set up the trend size and colour depth to send.  Note: Gabbro requires PNG8/64 colours, so we set the MSbit to true for that platform.
+    trend_size.width = PBL_DISPLAY_WIDTH;
+    trend_size.height = TREND_HEIGHT;
+#ifdef PBL_PLATFORM_GABBRO
+	trend_size.rgb8 = 1; 
+#endif
 
 	LOG("send_cmd_cgm: Creating Dictionary.");
 
@@ -1600,9 +1639,11 @@ static void send_cmd_cgm(void)
 // Set the trend size to send to xDrip+.  See xdrip.h
 	dict_write_uint32(iter, PBL_TREND_SIZE, trend_size.raw);
 	dict_write_end(iter);
+
+
+#endif
+
 	TRACE("send_cmd_cgm: Opening outbox");
-
-
 	sendcmd_senderr = app_message_outbox_send();
 
 	if (sendcmd_senderr != APP_MSG_OK && sendcmd_senderr != APP_MSG_BUSY && sendcmd_senderr != APP_MSG_SEND_REJECTED)
@@ -1611,7 +1652,6 @@ static void send_cmd_cgm(void)
 	}
 	//free(iter);
 	TRACE("send_cmd_cgm: done");
-
 } // end send_cmd_cgm
 
 // updateColours - called when fg_colour or bg_colour is changed.
@@ -2055,9 +2095,20 @@ void inbox_received_handler_cgm(DictionaryIterator *iterator, void *context)
 					//load_battlevel();
 				}
 			break;
+            case FRAMEWORK_HEARTBEAT:
+            case FRAMEWORK_VIBE:
+            case FRAMEWORK_MESSAGE:
+            case FRAMEWORK_LOWLIMIT:
+            case FRAMEWORK_HIGHLIMIT:
+            case FRAMEWORK_SLOPEVAL:
+            case FRAMEWORK_BGL_VALUE:
+            case FRAMEWORK_BGL_SERIES:
+            case FRAMEWORK_BGL_DELTA:
+                comm_handle(data);
+                break;
 
 			default:
-				LOG("inbox_received_handler_cgm: Dictionary Key not recognised");
+				LOG("inbox_received_handler_cgm: Dictionary Key not recognised: %ld", data->key);
 			break;
 		}
 		// end switch(key)
@@ -2916,6 +2967,18 @@ static void init_cgm(void)
 	const bool animated_cgm = true;
 	window_stack_push(window_cgm, animated_cgm);
 
+#ifdef ENABLE_COMM_FRAMEWORK
+    comm_callbacks.bgl_data = NULL;
+    comm_callbacks.bgl_series = NULL;
+    comm_callbacks.low_limit = set_low_limit;
+    comm_callbacks.high_limit = set_high_limit;
+    comm_callbacks.phonebat = set_phone_battery;
+    comm_callbacks.slopeval = set_icon;
+    comm_callbacks.vibe = set_vibrate;
+    comm_callbacks.bgl_delta = set_bgl_delta;
+    comm_init(&comm_callbacks);
+#endif
+
 	LOG("init_cgm done.");
 }	// end init_cgm
 
@@ -2969,6 +3032,60 @@ static void deinit_cgm(void)
 
 	TRACE("DEINIT CODE OUT");
 } // end deinit_cgm
+
+#ifdef ENABLE_COMM_FRAMEWORK
+/*
+ * Comm framework callback functions
+ */
+void set_icon(comm_slopeval value) {
+    current_icon = value;
+    load_icon();
+}
+
+void set_high_limit(comm_high_limit value) {
+    // do  nothing for now
+}
+
+void set_low_limit(comm_high_limit value) {
+    // do  nothing for now
+}
+
+void set_phone_battery(comm_phonebat value) {
+    last_battlevel = value;
+    load_battlevel();
+}
+
+// snprintf does not support float!
+void set_bgl_delta(comm_bgl_delta value) {
+    DEBUG("Delta units: neg: %d mmol: %d display: %d value: %d", value.is_neg, value.is_mmol, value.display_units, value.value);
+    if (value.value == 0x3FFF) {
+        snprintf(current_bg_delta, sizeof(current_bg_delta), "???");
+    } else if (value.is_mmol && value.display_units) {
+        TRACE("MMOL + Display");
+        int delta_point = MGDL_TO_MMOL_DEC(value.is_neg ? value.value * -1 : value.value);
+        int delta = MGDL_TO_MMOL(value.is_neg ? value.value * -1 : value.value);
+        snprintf(current_bg_delta, sizeof(current_bg_delta), "%d.%d mmol/l", delta, delta_point);
+    } else if (value.display_units && !value.is_mmol) {
+        TRACE("MG + Display");
+        int16_t delta = value.is_neg ? -1 * value.value : value.value;
+        snprintf(current_bg_delta, sizeof(current_bg_delta), "%hd mg/dL", delta);
+    } else if (value.is_mmol) {
+        TRACE("MMOL");
+        int delta_point = MGDL_TO_MMOL_DEC(value.is_neg ? value.value * -1 : value.value);
+        int delta = MGDL_TO_MMOL(value.is_neg ? value.value * -1 : value.value);
+        snprintf(current_bg_delta, sizeof(current_bg_delta), "%d.%d", delta, delta_point);
+    } else {
+        TRACE("MG");
+        int16_t delta = value.is_neg ? -1 * value.value : value.value;
+        snprintf(current_bg_delta, sizeof(current_bg_delta), "%hd", delta);
+    }
+    load_bg_delta();
+}
+
+void set_vibrate(comm_vibe value) {
+    if (!BluetoothAlert) alert_handler_cgm(value);
+}
+#endif
 
 int main(void)
 {

--- a/src/c/xdrip.c
+++ b/src/c/xdrip.c
@@ -1,7 +1,7 @@
 #include <pebble.h>
 #include "xdrip.h" // set DEBUG_LEVEL in here or on the pebble build command line
 #include "debug.h" // must be included after xdrip.h
-
+#include "api/communication.h"
 /**
  * Variables
  */
@@ -1565,16 +1565,18 @@ static void load_battlevel()
 // Needs to include configuration values that xDrip can read and respond to.
 static void send_cmd_cgm(void)
 {
-	uint32_t trend_size;
+	comm_trend_size trend_size;
 	DictionaryIterator *iter = NULL;
 	LOG("send_cmd_cgm called.");
 	AppMessageResult sendcmd_openerr = APP_MSG_OK;
 	AppMessageResult sendcmd_senderr = APP_MSG_OK;
 
+    trend_size.raw = 0;
 	//set up the trend size and colour depth to send.  Note: Gabbro requires PNG8/64 colours, so we set the MSbit to true for that platform.
-	trend_size = (uint32_t)((PBL_DISPLAY_WIDTH << 8) | TREND_HEIGHT);
+    trend_size.width = PBL_DISPLAY_WIDTH;
+    trend_size.height = TREND_HEIGHT;
 #ifdef PBL_PLATFORM_GABBRO
-	trend_size = trend_size || 0x80000000;
+	trend_size.rgb8 = 1; 
 #endif
 	sendcmd_openerr = app_message_outbox_begin(&iter);
 	if(BluetoothAlert)
@@ -1596,7 +1598,7 @@ static void send_cmd_cgm(void)
 	dict_write_uint8(iter, PBL_PLATFORM, (uint8_t) PLATFORM);
 	dict_write_cstring(iter, PBL_APP_VER, FACE_VERSION);
 // Set the trend size to send to xDrip+.  See xdrip.h
-	dict_write_uint32(iter, PBL_TREND_SIZE, trend_size);
+	dict_write_uint32(iter, PBL_TREND_SIZE, trend_size.raw);
 	dict_write_end(iter);
 	TRACE("send_cmd_cgm: Opening outbox");
 

--- a/src/c/xdrip.h
+++ b/src/c/xdrip.h
@@ -1,6 +1,6 @@
 //xdrip.h - file for all common defines and function prototypes used in xdrip.c
 #ifndef __XDRIP_H__
-#define __XDRIP_H
+#define __XDRIP_H__
 
 #include "constant.h"
 /**
@@ -16,7 +16,7 @@
 #define DEBUG_APP_INFO 1
 #define DEBUG_APP_NONE 0
 
-//#define DEBUG_LEVEL DEBUG_APP_TRACE 
+#define DEBUG_LEVEL DEBUG_APP_TRACE 
 
 /* The line below, if defined, will only indicate test values on the display.
 this is for testing purposes only until I can get the PebbleKit.JS code operating with the emulator.
@@ -24,6 +24,7 @@ Make sure you udefine this before building a release.
 */
 /* #define TEST_MODE */
 
+#define ENABLE_COMM_FRAMEWORK
 
 /** 
  * Face name
@@ -102,6 +103,9 @@ static void bitmapLayerUpdate(struct Layer *layer, GContext *ctx);
 #else
 #define TREND_HEIGHT	64
 #endif
+
+#define MGDL_TO_MMOL(x)      ((int) ((float) x / 18.016)) 
+#define MGDL_TO_MMOL_DEC(x)  ((int) (10.0 * (((float) x / 18.016) - MGDL_TO_MMOL(x))))
 
 // Function Prototypes
 // These two are only used if DEBUG_LEVEL is defined.  The code is conditinally compiled otherwise there are warnings.

--- a/src/c/xdrip.h
+++ b/src/c/xdrip.h
@@ -16,7 +16,7 @@
 #define DEBUG_APP_INFO 1
 #define DEBUG_APP_NONE 0
 
-#define DEBUG_LEVEL DEBUG_APP_TRACE 
+/* #define DEBUG_LEVEL DEBUG_APP_TRACE  */
 
 /* The line below, if defined, will only indicate test values on the display.
 this is for testing purposes only until I can get the PebbleKit.JS code operating with the emulator.
@@ -24,7 +24,11 @@ Make sure you udefine this before building a release.
 */
 /* #define TEST_MODE */
 
+/**
+ * Feature flags
+ */
 #define ENABLE_COMM_FRAMEWORK
+#define ENABLE_TREND_RENDERER
 
 /** 
  * Face name

--- a/src/c/xdrip.h
+++ b/src/c/xdrip.h
@@ -2,6 +2,7 @@
 #ifndef __XDRIP_H__
 #define __XDRIP_H__
 
+#include <math.h>
 #include "constant.h"
 /**
  * Defines for testing modes
@@ -109,7 +110,7 @@ static void bitmapLayerUpdate(struct Layer *layer, GContext *ctx);
 #endif
 
 #define MGDL_TO_MMOL(x)      ((int) ((float) x / 18.016)) 
-#define MGDL_TO_MMOL_DEC(x)  ((int) (10.0 * (((float) x / 18.016) - MGDL_TO_MMOL(x))))
+#define MGDL_TO_MMOL_DEC(x)  ((int) round(10.0 * (((float) x / 18.016) - MGDL_TO_MMOL(x))))
 
 // Function Prototypes
 // These two are only used if DEBUG_LEVEL is defined.  The code is conditinally compiled otherwise there are warnings.


### PR DESCRIPTION
This contains all changes to the comms/trend generation I made. Mostly follows the framework.md document, except for some instances where it made less sense (e.g. the delta/series values). Due to how it's now done you do not need multiple staged messages and can send everything in one burst and let the pebble framework figure out how to handle it.