### PR TITLE
Add show/hide toggles for the trend high/low threshold lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,8 @@
       "trend_hour": 320,
       "trend_hour_width": 321,
       "trend_hour_style": 322,
+      "show_high_line": 323,
+      "show_low_line": 324,
       "sync": 1000,
       "platform": 1001,
       "version": 1002,

--- a/src/c/api/trend.c
+++ b/src/c/api/trend.c
@@ -48,6 +48,8 @@ void trend_init(Layer *layer) {
     /* Values for high/low lines */
     config.bgl_high_line = persist_exists(SET_HIGH_LINE_VALUE) ? persist_read_int(SET_HIGH_LINE_VALUE) : 180;
     config.bgl_low_line = persist_exists(SET_LOW_LINE_VALUE) ? persist_read_int(SET_LOW_LINE_VALUE) : 72;
+    config.show_high_line = persist_exists(SET_SHOW_HIGH_LINE) ? persist_read_bool(SET_SHOW_HIGH_LINE) : true;
+    config.show_low_line = persist_exists(SET_SHOW_LOW_LINE) ? persist_read_bool(SET_SHOW_LOW_LINE) : true;
     config.bgl_high_limit = persist_exists(SET_HIGH_LIMIT) ? persist_read_int(SET_HIGH_LIMIT) : 250;
     config.bgl_low_limit = persist_exists(SET_LOW_LIMIT) ? persist_read_int(SET_LOW_LIMIT) : 40;
 
@@ -224,13 +226,13 @@ static bool draw_trend_lines(Layer *layer, GContext *ctx) {
     switch (config.hl_line_style) {
         default:
         case TREND_LINE_STYLE_EDGES:
-            if (config.bgl_high_line) {
+            if (config.bgl_high_line && config.show_high_line) {
                 graphics_context_set_stroke_color(ctx, COLOR_FALLBACK(config.high_line_color, GColorWhite));
                 graphics_draw_line(ctx, (GPoint) { 0, h }, (GPoint) { bounds.size.w / 5, h});
                 graphics_draw_line(ctx, (GPoint) { bounds.size.w - (bounds.size.w / 5), h }, (GPoint) { bounds.size.w, h});
 
             }
-            if (config.bgl_low_line) {
+            if (config.bgl_low_line && config.show_low_line) {
                 graphics_context_set_stroke_color(ctx, COLOR_FALLBACK(config.low_line_color, GColorWhite));
                 graphics_draw_line(ctx, (GPoint) { 0, l }, (GPoint) { bounds.size.w / 5, l});
                 graphics_draw_line(ctx, (GPoint) { bounds.size.w - (bounds.size.w / 5), l }, (GPoint) { bounds.size.w, l});
@@ -239,11 +241,11 @@ static bool draw_trend_lines(Layer *layer, GContext *ctx) {
         case TREND_LINE_STYLE_SOLID:
 #endif
             TRACE(TREND_LOG "Lines -> Solid");
-            if (config.bgl_high_line) {
+            if (config.bgl_high_line && config.show_high_line) {
                 graphics_context_set_stroke_color(ctx, COLOR_FALLBACK(config.high_line_color, GColorWhite));
                 graphics_draw_line(ctx, (GPoint) { 0, h }, (GPoint) { bounds.size.w, h});
             }
-            if (config.bgl_low_line) {
+            if (config.bgl_low_line && config.show_low_line) {
                 graphics_context_set_stroke_color(ctx, COLOR_FALLBACK(config.low_line_color, GColorWhite));
                 graphics_draw_line(ctx, (GPoint) { 0, l }, (GPoint) { bounds.size.w, l});
             }
@@ -256,13 +258,13 @@ static bool draw_trend_lines(Layer *layer, GContext *ctx) {
         case TREND_LINE_STYLE_DOTTED:
             TRACE(TREND_LOG "Lines -> Dotted");
             s += 2;
-            if (config.bgl_high_line) {
+            if (config.bgl_high_line && config.show_high_line) {
                 graphics_context_set_stroke_color(ctx, COLOR_FALLBACK(config.high_line_color, GColorWhite));
                 for (int x = 0; x < bounds.size.w; x+=s) {
                     graphics_draw_pixel(ctx, (GPoint) { x, h });
                 }
             }
-            if (config.bgl_low_line) {
+            if (config.bgl_low_line && config.show_low_line) {
                 graphics_context_set_stroke_color(ctx, COLOR_FALLBACK(config.low_line_color, GColorWhite));
                 for (int x = 0; x < bounds.size.w; x+=s) {
                     graphics_draw_pixel(ctx, (GPoint) { x, l });
@@ -278,13 +280,13 @@ static bool draw_trend_lines(Layer *layer, GContext *ctx) {
             TRACE(TREND_LOG "Lines -> Dashed");
             s += 2;
             w += 2;
-            if (config.bgl_high_line) {
+            if (config.bgl_high_line && config.show_high_line) {
                 graphics_context_set_stroke_color(ctx, COLOR_FALLBACK(config.high_line_color, GColorWhite));
                 for (int x = 0; x < bounds.size.w; x+=s+w) {
                     graphics_draw_line(ctx, (GPoint) { x, h }, (GPoint) { x+w, h});
                 }
             }
-            if (config.bgl_low_line) {
+            if (config.bgl_low_line && config.show_low_line) {
                 graphics_context_set_stroke_color(ctx, COLOR_FALLBACK(config.low_line_color, GColorWhite));
                 for (int x = 0; x < bounds.size.w; x+=s+w) {
                     graphics_draw_line(ctx, (GPoint) { x, l }, (GPoint) { x+w, l});
@@ -485,6 +487,16 @@ void trend_process_config(Tuple *data) {
         case SET_HOUR_WIDTH:
             persist_write_int(SET_HOUR_WIDTH, data->value->int8);
             config.hour_line_width = data->value->int8;
+            trend_draw();
+            break;
+        case SET_SHOW_HIGH_LINE:
+            config.show_high_line = (data->value->uint8 != 0);
+            persist_write_bool(SET_SHOW_HIGH_LINE, config.show_high_line);
+            trend_draw();
+            break;
+        case SET_SHOW_LOW_LINE:
+            config.show_low_line = (data->value->uint8 != 0);
+            persist_write_bool(SET_SHOW_LOW_LINE, config.show_low_line);
             trend_draw();
             break;
         default:

--- a/src/c/api/trend.h
+++ b/src/c/api/trend.h
@@ -57,6 +57,8 @@ typedef struct {
     int16_t     bgl_critical;       // Critical value
     int16_t     bgl_high_line;      // High line value
     int16_t     bgl_low_line;       // Low line value
+    bool        show_high_line;     // Draw the high threshold line
+    bool        show_low_line;      // Draw the low threshold line
     int16_t     bgl_high_limit;     // Gigh graph limit
     int16_t     bgl_low_limit;      // Low graph limit 
     Layer       *layer;             // Layer to draw into

--- a/src/c/xdrip.h
+++ b/src/c/xdrip.h
@@ -108,6 +108,8 @@ Make sure you udefine this before building a release.
 #define SET_HOUR_ENABLED        320
 #define SET_HOUR_WIDTH          321
 #define SET_HOUR_STYLE          322
+#define SET_SHOW_HIGH_LINE      323	// Setting key - draw the high threshold line on the trend graph
+#define SET_SHOW_LOW_LINE       324	// Setting key - draw the low threshold line on the trend graph
 #define CGM_SYNC_KEY			1000	// key pebble will use to request an update.	This should probably include the "capabilities" bits
 #define PBL_PLATFORM			1001	// key pebble will use to send it's platform	This is probably not required under the new famework.
 #define PBL_APP_VER			1002	// key pebble will use to send the face/app version.	This is probably not required under the new framework.

--- a/src/js/config.json
+++ b/src/js/config.json
@@ -398,6 +398,20 @@
               "max": 400
           },
           {
+              "type": "toggle",
+              "messageKey": "show_high_line",
+              "label": "Show high threshold line",
+              "defaultValue": true,
+              "group": "trend_lines"
+          },
+          {
+              "type": "toggle",
+              "messageKey": "show_low_line",
+              "label": "Show low threshold line",
+              "defaultValue": true,
+              "group": "trend_lines"
+          },
+          {
               "type": "color",
               "messageKey": "trend_high_line_color",
               "label": "High line Color",

--- a/src/js/custom.js
+++ b/src/js/custom.js
@@ -14,6 +14,8 @@ module.exports = function(minified) {
             'trend_low_color',
             'trend_high_line_color',
             'trend_low_line_color',
+            'show_high_line',
+            'show_low_line',
             'trend_low',
             'trend_average',
             'trend_high',


### PR DESCRIPTION
## What

The native trend renderer always draws the high line (default 180) in red and the low line (default 72) in blue across the graph. There was no way to turn them off — the `nohighline`/`nolowline` keys (110/111) were defined but unhandled, and 111 collides with xDrip's `NO_BLUETOOTH_KEY`.

Adds real per-line visibility:

- New keys **`SET_SHOW_HIGH_LINE` (323)** / **`SET_SHOW_LOW_LINE` (324)** (next free after the hour-line keys).
- `trend_config.show_high_line` / `show_low_line`, persisted, read in `trend_init` (**default `true`** — no change for existing users), handled in `trend_process_config`.
- Every branch of `draw_trend_lines` (solid / dotted / dashed / edges) now also checks the flag.
- Clay config: **"Show high threshold line"** / **"Show low threshold line"** toggles, grouped with the other trend-line settings so they grey out under *Use xDrip image*.

## Companion

xDrip PR wires keys 323/324 to the existing **`pebble_high_line` / `pebble_low_line`** preferences (both default off), so unchecking "Displays the high line" / "Displays the low line" in xDrip's advanced settings hides them on the native renderer too — matching how those checkboxes already behave for the PNG renderer.

## Testing

`pebble build` clean for all six platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
