### PR TITLE
Likely fix for app message state error causing send to no longer function

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
       "trend_hour": 320,
       "trend_hour_width": 321,
       "trend_hour_style": 322,
+      "trend_auto_adjust_max": 323,
       "sync": 1000,
       "platform": 1001,
       "version": 1002,

--- a/src/c/api/trend.c
+++ b/src/c/api/trend.c
@@ -61,10 +61,14 @@ void trend_init(Layer *layer) {
 
     TRACE(TREND_LOG "Setting callback");
     layer_set_update_proc((Layer *) config.layer, trend_layer_callback);
+    layer_set_hidden(config.layer, false);
 }
 
 void trend_deinit(void) {
-    if (config.layer != NULL) layer_set_update_proc(config.layer, NULL); // discard
+    if (config.layer != NULL) {
+        layer_set_hidden(config.layer, true);
+        layer_set_update_proc(config.layer, NULL); // discard
+    }
     config.layer = NULL;
     config.bgl.initialized = 0;
 }

--- a/src/c/api/trend.c
+++ b/src/c/api/trend.c
@@ -383,7 +383,6 @@ void trend_draw(void) {
 
 void trend_set_series(comm_bgl_series *values) {
 
-#ifndef PBL_PLATFORM_APLITE
     TRACE(TREND_LOG "Trend set series"); 
     if (!config.bgl.initialized) {
         DEBUG("Initializing");
@@ -402,7 +401,6 @@ void trend_set_series(comm_bgl_series *values) {
         config.bgl.index = config.bgl.index % (config.bgl.size);
     }
     trend_draw();
-#endif
 }
 
 void trend_set_value(comm_bgl_data *value) {

--- a/src/c/api/trend.c
+++ b/src/c/api/trend.c
@@ -348,7 +348,6 @@ static bool draw_trend_lines(Layer *layer, GContext *ctx) {
                         graphics_draw_pixel(ctx, (GPoint) { i, y });
                     }
                     break;
-                case TREND_LINE_STYLE_EDGES:
                     graphics_draw_line(ctx, (GPoint) { (int) i, 0 }, (GPoint) { (int) i, bounds.size.h / 5});
                     graphics_draw_line(ctx, (GPoint) { (int) i, bounds.size.h - (bounds.size.h / 5) }, (GPoint) { (int) i, bounds.size.h});
                     break;
@@ -405,9 +404,9 @@ void trend_set_series(comm_bgl_series *values) {
 
 void trend_set_value(comm_bgl_data *value) {
     TRACE(TREND_LOG "Trend set value");
-    config.bgl.values[config.bgl.index % (config.bgl.size - 1)] = value->bgl.value;
+    config.bgl.values[config.bgl.index % (config.bgl.size)] = value->bgl.value;
     config.bgl.index++;
-    config.bgl.index = config.bgl.index % (config.bgl.size - 1);
+    config.bgl.index = config.bgl.index % (config.bgl.size);
     trend_draw();
 
 }

--- a/src/c/api/trend.c
+++ b/src/c/api/trend.c
@@ -34,15 +34,21 @@ void trend_init(Layer *layer) {
     config.average_color = persist_exists(SET_BGL_AVERAGE_COLOUR) ? GColorFromHEX(persist_read_int(SET_BGL_AVERAGE_COLOUR)) : COLOR_FALLBACK(GColorYellow, GColorWhite);
     config.good_color = persist_exists(SET_BGL_GOOD_COLOUR) ? GColorFromHEX(persist_read_int(SET_BGL_GOOD_COLOUR)) : COLOR_FALLBACK(GColorGreen, GColorWhite);
     config.low_color = persist_exists(SET_BGL_LOW_COLOUR) ? GColorFromHEX(persist_read_int(SET_BGL_LOW_COLOUR)) : COLOR_FALLBACK(GColorBlue, GColorWhite);
+    config.high_line_color = persist_exists(SET_HIGH_LINE_COLOUR) ? GColorFromHEX(persist_read_int(SET_HIGH_LINE_COLOUR)) : COLOR_FALLBACK(GColorRed, GColorWhite);
+    config.low_line_color = persist_exists(SET_LOW_LINE_COLOUR) ? GColorFromHEX(persist_read_int(SET_LOW_LINE_COLOUR)) : COLOR_FALLBACK(GColorBlue, GColorWhite);
+
+    /* Colors */
     config.bgl_low = persist_exists(SET_BGL_LOW) ? persist_read_int(SET_BGL_LOW) : 72;
     config.bgl_average = persist_exists(SET_BGL_AVERAGE) ? persist_read_int(SET_BGL_AVERAGE) : 144;
     config.bgl_high = persist_exists(SET_BGL_HIGH) ? persist_read_int(SET_BGL_HIGH) : 190;
     config.bgl_critical = persist_exists(SET_BGL_CRITICAL) ? persist_read_int(SET_BGL_CRITICAL) : 210;
-    config.high_line_color = persist_exists(SET_HIGH_LINE_COLOUR) ? GColorFromHEX(persist_read_int(SET_HIGH_LINE_COLOUR)) : COLOR_FALLBACK(GColorRed, GColorWhite);
-    config.low_line_color = persist_exists(SET_LOW_LINE_COLOUR) ? GColorFromHEX(persist_read_int(SET_LOW_LINE_COLOUR)) : COLOR_FALLBACK(GColorBlue, GColorWhite);
-    config.trend_width = persist_exists(SET_TREND_WIDTH) ? persist_read_int(SET_TREND_WIDTH) : 4;
+
+    /* Styles */
     config.style = persist_exists(SET_TREND_STYLE) ? persist_read_int(SET_TREND_STYLE) : TREND_STYLE_DOTS;
     config.hl_line_style = persist_exists(SET_LINE_STYLE) ? persist_read_int(SET_LINE_STYLE) : TREND_LINE_STYLE_SOLID;
+
+    /* Line widths */
+    config.trend_width = persist_exists(SET_TREND_WIDTH) ? persist_read_int(SET_TREND_WIDTH) : 4;
     config.line_width = persist_exists(SET_LINE_WIDTH) ? persist_read_int(SET_LINE_WIDTH) : 4;
 
     /* Values for high/low lines */
@@ -56,6 +62,9 @@ void trend_init(Layer *layer) {
     config.hour_line_width = persist_exists(SET_HOUR_WIDTH) ? persist_read_int(SET_HOUR_WIDTH) : 1;
     config.hour_line_style = persist_exists(SET_HOUR_STYLE) ? persist_read_int(SET_HOUR_STYLE) : TREND_LINE_STYLE_SOLID;
     config.hour_line_enabled = persist_exists(SET_HOUR_ENABLED) ? persist_read_int(SET_HOUR_ENABLED) : 0;
+
+    /* other */
+    config.auto_adjust_max = persist_exists(SET_AUTO_ADJUST_MAX) ? persist_read_int(SET_AUTO_ADJUST_MAX) : 0;
 
     config.bgl.initialized = 0;
 
@@ -214,8 +223,18 @@ static bool draw_trend_lines(Layer *layer, GContext *ctx) {
     // top is 0,0
     // excape if no line needs to be drawn
     GRect bounds = layer_get_bounds(layer);
-    const int16_t h = BGL_TO_Y(config.bgl_high_line, config, bounds); 
-    const int16_t l = BGL_TO_Y(config.bgl_low_line, config, bounds); 
+    int16_t h = 0;
+    int16_t l = 0;
+    int16_t highest = 0, limit = config.bgl_high_limit;
+    if (config.auto_adjust_max) {
+        for (int i = 0; i < config.bgl.size; i++) {
+            if (config.bgl.values[i] > highest) highest = config.bgl.values[i];
+        }
+        config.bgl_high_limit = highest > config.bgl_high_line + (config.bgl_high_line / 20)? highest : config.bgl_high_line + (config.bgl_high_line / 20);
+    }
+    h = BGL_TO_Y(config.bgl_high_line, config, bounds); 
+    l = BGL_TO_Y(config.bgl_low_line, config, bounds); 
+    if (config.auto_adjust_max) config.bgl_high_limit = limit;
     TRACE(TREND_LOG "Draw lines, high: %d, low %d", h, l);
 
 #ifndef PBL_PLATFORM_APLITE
@@ -488,6 +507,11 @@ void trend_process_config(Tuple *data) {
             break;
         case SET_HOUR_WIDTH:
             persist_write_int(SET_HOUR_WIDTH, data->value->int8);
+            config.hour_line_width = data->value->int8;
+            trend_draw();
+            break;
+        case SET_AUTO_ADJUST_MAX:
+            persist_write_int(SET_AUTO_ADJUST_MAX, data->value->int8);
             config.hour_line_width = data->value->int8;
             trend_draw();
             break;

--- a/src/c/api/trend.h
+++ b/src/c/api/trend.h
@@ -5,6 +5,38 @@
 #include "communication.h"
 
 
+/*
+ * Settings from clay
+ */
+#define SET_USE_PNG             117
+#define SET_SHOW_UNIT           118
+#define SET_SHOW_DELTA          119
+#define SET_SHOW_SLOPE          120
+#define SET_SHOW_TREND          121
+#define SET_BGL_CRITICAL_COLOUR  301
+#define SET_BGL_HIGH_COLOUR      302
+#define SET_BGL_AVERAGE_COLOUR   303
+#define SET_BGL_GOOD_COLOUR      304
+#define SET_BGL_LOW_COLOUR       305
+#define SET_BGL_LOW             306
+#define SET_BGL_AVERAGE         307
+#define SET_BGL_HIGH            308
+#define SET_BGL_CRITICAL        309
+#define SET_LOW_LINE_COLOUR      310
+#define SET_HIGH_LINE_COLOUR     311
+#define SET_LINE_STYLE          312
+#define SET_LINE_WIDTH          313
+#define SET_TREND_STYLE         314
+#define SET_TREND_WIDTH         315
+#define SET_HIGH_LIMIT          316
+#define SET_HIGH_LINE_VALUE     317
+#define SET_LOW_LIMIT           318
+#define SET_LOW_LINE_VALUE      319
+#define SET_HOUR_ENABLED        320
+#define SET_HOUR_WIDTH          321
+#define SET_HOUR_STYLE          322
+#define SET_AUTO_ADJUST_MAX     323
+
 #define TREND_LOG "TREND :: "
 
 typedef int16_t trend_bgl_value; 
@@ -48,7 +80,9 @@ typedef struct {
     GColor      low_line_color;     // Colour of low line
     GColor      hour_line_color;
     int8_t      hour_line_width;
-    int8_t      hour_line_enabled;  
+    int8_t      hour_line_enabled : 1;
+    int8_t      auto_adjust_max : 1;
+    int8_t      : 6;
     int8_t      line_width;         // High/low line width
     int8_t      trend_width;        // Trend line width
     int16_t     bgl_low;            // Low value

--- a/src/c/xdrip.c
+++ b/src/c/xdrip.c
@@ -215,6 +215,8 @@ static char *translate_app_error(AppMessageResult result)
 			return "APP_MSG_CLOSED";
 		case APP_MSG_INTERNAL_ERROR:
 			return "APP_MSG_INTERNAL_ERROR";
+        case APP_MSG_INVALID_STATE:
+            return "APP_MSG_INVALID_STATE";
 		default:
 			return "APP UNKNOWN ERROR";
 	}
@@ -963,7 +965,7 @@ void outbox_failed_handler_cgm(DictionaryIterator *failed, AppMessageResult appm
 
 	// APPMSG OUT FAIL debug logs
 //	INFO("APPMSG OUT FAIL ERROR");
-	DEBUG("outbox_failed_handler_cgm: ERR CODE: %i RES: %s", appmsg_outfail_error, translate_app_error(appmsg_outfail_error));
+	ERROR("outbox_failed_handler_cgm: ERR CODE: %i RES: %s", appmsg_outfail_error, translate_app_error(appmsg_outfail_error));
 
 	bluetooth_connected_cgm = bluetooth_connection_service_peek();
 
@@ -1556,13 +1558,17 @@ static void send_cmd_cgm(void)
 	AppMessageResult sendcmd_senderr = APP_MSG_OK;
 	DictionaryIterator *iter = NULL;
 
-	sendcmd_openerr = app_message_outbox_begin(&iter);
 	if(BluetoothAlert)
 	{
 		//BT is down rignt now, so don't do anything.
 		//Note, we cannot log this, as BT must be up in order to log it.
 		return;
 	}
+
+    // if bt escapes early (above) outbox_begin MAY NOT be triggered as it will leave the outbox in
+    // an unrecoverable state, the entire function must be performed if app_message_outbox_begin succeeds.
+	sendcmd_openerr = app_message_outbox_begin(&iter);
+
 	if (sendcmd_openerr != APP_MSG_OK)
 	{
 		ERROR("send_cmd_cgm: ERR CODE: %i RES: %s", sendcmd_openerr, translate_app_error(sendcmd_openerr));

--- a/src/c/xdrip.c
+++ b/src/c/xdrip.c
@@ -109,7 +109,8 @@ TextLayer *date_app_layer = NULL;
 
 // bitmap layer definitions
 BitmapLayer *icon_layer = NULL;
-BitmapLayer *bg_trend_layer = NULL;
+BitmapLayer *bg_trend_layer_draw = NULL;
+BitmapLayer *bg_trend_layer_png = NULL;
 BitmapLayer *upper_face_layer = NULL;
 BitmapLayer *lower_face_layer = NULL;
 
@@ -1605,7 +1606,7 @@ static void send_cmd_cgm(void)
         hb.send_delta_value = 1;
         dict_write_uint32(iter, FRAMEWORK_BGL_VALUE, current_cgm_time); // request update
         if (use_png) {
-            comm_request_png(iter, layer_get_bounds(bitmap_layer_get_layer(bg_trend_layer)));
+            comm_request_png(iter, layer_get_bounds(bitmap_layer_get_layer(bg_trend_layer_png)));
         }
     }
 
@@ -1869,8 +1870,13 @@ void inbox_received_handler_cgm(DictionaryIterator *iterator, void *context)
                 DEBUG("PNG set to %d %d", use_png, data->value->int32);
                 persist_write_bool(SET_USE_PNG, use_png);
                 // reinit
-                if (!use_png) trend_init(bitmap_layer_get_layer(bg_trend_layer));
-                else trend_deinit();
+                if (!use_png) {
+                    trend_init(bitmap_layer_get_layer(bg_trend_layer_draw));
+                    layer_set_hidden(bitmap_layer_get_layer(bg_trend_layer_png), true);
+                } else {
+                    trend_deinit();
+                    layer_set_hidden(bitmap_layer_get_layer(bg_trend_layer_png), false);
+                }
                 // reset
                 dirty.need_cgm = 1;
                 current_cgm_time = 0; // force update all
@@ -1897,7 +1903,7 @@ void inbox_received_handler_cgm(DictionaryIterator *iterator, void *context)
             case SET_SHOW_TREND:
                 show_trend = data->value->uint8 != 0;
                 persist_write_bool(SET_SHOW_TREND, show_trend);
-                layer_set_hidden(bitmap_layer_get_layer(bg_trend_layer), !show_trend);
+                layer_set_hidden(bitmap_layer_get_layer(bg_trend_layer_png), !show_trend);
                 break;
 */
             /**
@@ -2064,8 +2070,10 @@ void window_load_cgm(Window *window_cgm)
 	// icon layer dimensions
 	icon_layer = bitmap_layer_create(GRect(85, -7, 78, 51));
 	// trend bitmap layer dimensions
-	bg_trend_layer = bitmap_layer_create(GRect(0,24,144,64));
-	bitmap_layer_set_compositing_mode(bg_trend_layer, GCompOpSet);
+	bg_trend_layer_png = bitmap_layer_create(GRect(0,24,144,64));
+	bitmap_layer_set_compositing_mode(bg_trend_layer_png, GCompOpSet);
+	bg_trend_layer_draw = bitmap_layer_create(GRect(0,24,144,64));
+	bitmap_layer_set_compositing_mode(bg_trend_layer_draw, GCompOpSet);
 	// delta layer dimensions
 	delta_layer = text_layer_create(GRect(0, 58, 143, 50));
 	text_layer_set_text_alignment(delta_layer, GTextAlignmentRight);
@@ -2105,8 +2113,10 @@ void window_load_cgm(Window *window_cgm)
 	icon_layer = bitmap_layer_create(GRect(85, -9, 78, 49));
 	bitmap_layer_set_compositing_mode(icon_layer, GCompOpSet);
 	// trend bitmap layer dimensions and composition mode
-	bg_trend_layer = bitmap_layer_create(GRect(0,0,144,84));
-	bitmap_layer_set_compositing_mode(bg_trend_layer, GCompOpSet);
+	bg_trend_layer_png = bitmap_layer_create(GRect(0,0,144,84));
+	bitmap_layer_set_compositing_mode(bg_trend_layer_png, GCompOpSet);
+	bg_trend_layer_draw = bitmap_layer_create(GRect(0,0,144,84));
+	bitmap_layer_set_compositing_mode(bg_trend_layer_draw, GCompOpSet);
 	// delta layer dimensions
 	delta_layer = text_layer_create(GRect(0, 58, 143, 50));
 	layer_set_bounds((Layer *) delta_layer, GRect(0, -2, 143, 50)); // fixes bounding box with latest sdk
@@ -2151,8 +2161,10 @@ void window_load_cgm(Window *window_cgm)
 	icon_layer = bitmap_layer_create(GRect(120, 30, 78, 50));
 	bitmap_layer_set_compositing_mode(icon_layer, GCompOpSet);
 	// trend bitmap layer dimensions and composition mode
-	bg_trend_layer = bitmap_layer_create(GRect(0,0,144,84));
-	bitmap_layer_set_compositing_mode(bg_trend_layer, GCompOpSet);
+	bg_trend_layer_png = bitmap_layer_create(GRect(0,0,144,84));
+	bitmap_layer_set_compositing_mode(bg_trend_layer_png, GCompOpSet);
+	bg_trend_layer_draw = bitmap_layer_create(GRect(0,0,144,84));
+	bitmap_layer_set_compositing_mode(bg_trend_layer_draw, GCompOpSet);
 	// delta layer dimensions
 	delta_layer = text_layer_create(GRect(0, 36, 180, 50));
 	text_layer_set_text_alignment(delta_layer, GTextAlignmentCenter);
@@ -2191,8 +2203,10 @@ void window_load_cgm(Window *window_cgm)
 	// icon layer dimensions
 	icon_layer = bitmap_layer_create(GRect(85, -7, 78, 51));
 	// trend bitmap layer dimensions
-	bg_trend_layer = bitmap_layer_create(GRect(0,24,144,64));
-	bitmap_layer_set_compositing_mode(bg_trend_layer, GCompOpSet);
+	bg_trend_layer_png = bitmap_layer_create(GRect(0,24,144,64));
+	bitmap_layer_set_compositing_mode(bg_trend_layer_png, GCompOpSet);
+	bg_trend_layer_draw = bitmap_layer_create(GRect(0,24,144,64));
+	bitmap_layer_set_compositing_mode(bg_trend_layer_draw, GCompOpSet);
 	// delta layer dimensions
 	delta_layer = text_layer_create(GRect(0, 58, 143, 50));
 	text_layer_set_text_alignment(delta_layer, GTextAlignmentRight);
@@ -2229,8 +2243,10 @@ void window_load_cgm(Window *window_cgm)
 	icon_layer = bitmap_layer_create(GRect(146, -9, 78, 49));
 	bitmap_layer_set_compositing_mode(icon_layer, GCompOpSet);
 	// trend bitmap layer dimensions and composition mode
-	bg_trend_layer = bitmap_layer_create(GRect(0,0,200,114));
-	bitmap_layer_set_compositing_mode(bg_trend_layer, GCompOpSet);
+	bg_trend_layer_png = bitmap_layer_create(GRect(0,0,200,114));
+	bitmap_layer_set_compositing_mode(bg_trend_layer_png, GCompOpSet);
+	bg_trend_layer_draw = bitmap_layer_create(GRect(0,0,200,114));
+	bitmap_layer_set_compositing_mode(bg_trend_layer_draw, GCompOpSet);
 	// delta layer dimensions
 	delta_layer = text_layer_create(GRect(2, 78, 198, 50));
 	text_layer_set_text_alignment(delta_layer, GTextAlignmentLeft);
@@ -2277,8 +2293,10 @@ void window_load_cgm(Window *window_cgm)
 	// icon layer dimensions
 	icon_layer = bitmap_layer_create(GRect(85, -7, 78, 51));
 	// trend bitmap layer dimensions
-	bg_trend_layer = bitmap_layer_create(GRect(0,24,144,64));
-	bitmap_layer_set_compositing_mode(bg_trend_layer, GCompOpSet);
+	bg_trend_layer_png = bitmap_layer_create(GRect(0,24,144,64));
+	bitmap_layer_set_compositing_mode(bg_trend_layer_png, GCompOpSet);
+	bg_trend_layer_draw = bitmap_layer_create(GRect(0,24,144,64));
+	bitmap_layer_set_compositing_mode(bg_trend_layer_draw, GCompOpSet);
 	// delta layer dimensions
 	delta_layer = text_layer_create(GRect(0, 58, 143, 50));
 	text_layer_set_text_alignment(delta_layer, GTextAlignmentLeft);
@@ -2320,8 +2338,10 @@ void window_load_cgm(Window *window_cgm)
 	icon_layer = bitmap_layer_create(GRect(173,  43, 112,  72));
 	bitmap_layer_set_compositing_mode(icon_layer, GCompOpSet);
 	// trend bitmap layer dimensions and composition mode
-	bg_trend_layer = bitmap_layer_create(GRect(  0,   0, 260, 121));
-	bitmap_layer_set_compositing_mode(bg_trend_layer, GCompOpSet);
+	bg_trend_layer_png = bitmap_layer_create(GRect(  0,   0, 260, 121));
+	bitmap_layer_set_compositing_mode(bg_trend_layer_png, GCompOpSet);
+	bg_trend_layer_draw = bitmap_layer_create(GRect(  0,   0, 260, 121));
+	bitmap_layer_set_compositing_mode(bg_trend_layer_draw, GCompOpSet);
 	// delta layer dimensions
 	delta_layer = text_layer_create(GRect(  0,  52, 260,  72));
 	text_layer_set_text_alignment(delta_layer, GTextAlignmentCenter);
@@ -2404,7 +2424,11 @@ void window_load_cgm(Window *window_cgm)
 	text_layer_set_text_alignment(message_layer, GTextAlignmentCenter);
 #endif
 
-	layer_add_child(window_layer_cgm, bitmap_layer_get_layer(bg_trend_layer));
+	layer_add_child(window_layer_cgm, bitmap_layer_get_layer(bg_trend_layer_png));
+	layer_add_child(window_layer_cgm, bitmap_layer_get_layer(bg_trend_layer_draw));
+
+    layer_set_hidden(bitmap_layer_get_layer(bg_trend_layer_png), !use_png);
+    layer_set_hidden(bitmap_layer_get_layer(bg_trend_layer_draw), use_png);
 
 	// ARROW OR SPECIAL VALUE
 	LOG("Creating Arrow Bitmap layer");
@@ -2512,7 +2536,7 @@ void window_load_cgm(Window *window_cgm)
 	load_battlevel();
 
     // default config
-    if (!use_png) trend_init(bitmap_layer_get_layer(bg_trend_layer));
+    if (!use_png) trend_init(bitmap_layer_get_layer(bg_trend_layer_draw));
 
 //	TRACE("WINDOW LOAD, ABOUT TO CALL APP SYNC INIT");
 	//app_sync_init(&sync_cgm, sync_buffer_cgm, sizeof(sync_buffer_cgm), initial_values_cgm, ARRAY_LENGTH(initial_values_cgm), sync_tuple_changed_callback_cgm, sync_error_callback_cgm, NULL);
@@ -2534,7 +2558,8 @@ void window_unload_cgm(Window *window_cgm)
 
 	//destroy the trend bitmap and layer
 	if(bg_trend_bitmap != NULL) destroy_null_GBitmap(&bg_trend_bitmap);
-	if(bg_trend_layer != NULL) destroy_null_BitmapLayer(&bg_trend_layer);
+	if(bg_trend_layer_draw != NULL) destroy_null_BitmapLayer(&bg_trend_layer_draw);
+	if(bg_trend_layer_png != NULL) destroy_null_BitmapLayer(&bg_trend_layer_png);
 	TRACE("window_unload_cgm: destroy existing GBitmaps");
 	if(icon_bitmap != NULL) destroy_null_GBitmap(&icon_bitmap);
 	if(appicon_bitmap != NULL) destroy_null_GBitmap(&appicon_bitmap);
@@ -2882,13 +2907,13 @@ void set_png(comm_png_data data) {
     if(bg_trend_bitmap != NULL)
     {
         LOG("bg_trend_bitmap created, setting to layer");
-        bitmap_layer_set_bitmap(bg_trend_layer, bg_trend_bitmap);
+        bitmap_layer_set_bitmap(bg_trend_layer_png, bg_trend_bitmap);
     }
     else
     {
         WARNING("bg_trend_bitmap creation FAILED!");
     }
-    layer_set_hidden(bitmap_layer_get_layer(bg_trend_layer), !show_trend);
+    layer_set_hidden(bitmap_layer_get_layer(bg_trend_layer_png), !show_trend);
     dirty.need_cgm = 0;
 }
 

--- a/src/c/xdrip.c
+++ b/src/c/xdrip.c
@@ -360,11 +360,9 @@ static void hr_draw_callback(void *context) {
     INFO("Drawing HRM");
     // defer HR update untill measurement stabelizes
     if(bottom_left_metric == METRIC_HEARTRATE && dirty.hbm) {
-        DEBUG("Setting bottom left metric to \"%lu\"", (uint32_t)val);
         text_layer_set_text(bottom_left_text_layer, s_hrm_buffer);
     }
     if(bottom_right_metric == METRIC_HEARTRATE && dirty.hbm) {
-        DEBUG("Setting bottom right metric to \"%lu\"", (uint32_t)val);
         text_layer_set_text(bottom_right_text_layer, s_hrm_buffer);
     }
     hr_draw_timer = NULL;
@@ -2397,6 +2395,7 @@ void window_load_cgm(Window *window_cgm)
 	layer_add_child(window_layer_cgm, bitmap_layer_get_layer(lower_face_layer));
 
 
+
 	//create the bg_trend_layer
 	INFO("Creating BG Trend Bitmap layer");
 #if DEBUG_LEVEL > 0
@@ -2410,7 +2409,7 @@ void window_load_cgm(Window *window_cgm)
 	// ARROW OR SPECIAL VALUE
 	LOG("Creating Arrow Bitmap layer");
 #if defined(PBL_PLATFORM_EMERY) || defined(PBL_PLATFORM_GABBRO)
-	layer_add_child(bitmap_layer_get_layer(bg_trend_layer), bitmap_layer_get_layer(icon_layer));
+	layer_add_child(window_layer_cgm, bitmap_layer_get_layer(icon_layer));
 #else
 	layer_add_child(window_layer_cgm, bitmap_layer_get_layer(icon_layer));
 #endif
@@ -2831,7 +2830,7 @@ void set_vibrate(comm_vibe value) {
 
 void set_bgl_timestamp(uint32_t timestamp) {
     TRACE("Set BGL Timestamp");
-    if (!dirty.need_cgm) current_cgm_time = timestamp;
+    if (!dirty.need_cgm || use_png) current_cgm_time = timestamp;
     reset_timer_callback_cgm((timestamp - time(NULL)) + (60 * 6));
     load_cgmtime();
 }

--- a/src/c/xdrip.c
+++ b/src/c/xdrip.c
@@ -898,7 +898,7 @@ void inbox_dropped_handler_cgm(AppMessageResult appmsg_indrop_error, void *conte
 	}
 
 	appmsg_indrop_openerr = app_message_outbox_begin(&iter);
-
+                                //
 	if (appmsg_indrop_openerr == APP_MSG_OK )
 	{
 		// reset AppMsgInDropAlert to flag for vibrate
@@ -982,7 +982,14 @@ void outbox_failed_handler_cgm(DictionaryIterator *failed, AppMessageResult appm
 		AppMsgOutFailAlert = false;
 
 		// send message
-		return;
+		AppMessageResult appsync_err_senderr = app_message_outbox_send();
+		TRACE("APP SYNC SEND ERR CODE: %i RES: %s", appsync_err_senderr, translate_app_error(appsync_err_senderr));
+		if (appsync_err_senderr != APP_MSG_OK  && appsync_err_senderr != APP_MSG_BUSY && appsync_err_senderr != APP_MSG_SEND_REJECTED)
+		{
+			INFO("APP SYNC SEND ERROR");
+			DEBUG("APP SYNC SEND ERR CODE: %i RES: %s", appsync_err_senderr, translate_app_error(appsync_err_senderr));
+		}
+        return;
 	}
 
 //	INFO("APPMSG OUT FAIL RESEND ERROR");
@@ -1571,7 +1578,8 @@ static void send_cmd_cgm(void)
 	if (sendcmd_openerr != APP_MSG_OK)
 	{
 		ERROR("send_cmd_cgm: ERR CODE: %i RES: %s", sendcmd_openerr, translate_app_error(sendcmd_openerr));
-		return;
+        // proceed to send since it's the only way to recover
+        goto send_appmsg;
 	}
     comm_heartbeat hb;
     hb.raw = 0; // reset
@@ -1614,9 +1622,11 @@ static void send_cmd_cgm(void)
 
 	dict_write_uint32(iter, FRAMEWORK_HEARTBEAT, hb.raw);
 
+    dict_write_end(iter);
+
+send_appmsg:
 	TRACE("send_cmd_cgm: Opening outbox");
 	sendcmd_senderr = app_message_outbox_send();
-
 	if (sendcmd_senderr != APP_MSG_OK && sendcmd_senderr != APP_MSG_BUSY && sendcmd_senderr != APP_MSG_SEND_REJECTED)
 	{
 		ERROR("send_cmd_cgm: ERR CODE: %i RES: %s", sendcmd_senderr, translate_app_error(sendcmd_senderr));

--- a/src/c/xdrip.h
+++ b/src/c/xdrip.h
@@ -24,7 +24,7 @@
 this is for testing purposes only until I can get the PebbleKit.JS code operating with the emulator.
 Make sure you udefine this before building a release.
 */
-#define TEST_MODE
+/* #define TEST_MODE */
 
 /**
  * Feature flags

--- a/src/c/xdrip.h
+++ b/src/c/xdrip.h
@@ -18,7 +18,7 @@
 #define DEBUG_APP_INFO 1
 #define DEBUG_APP_NONE 0
 
-/* #define DEBUG_LEVEL DEBUG_APP_INFO  */
+/* #define DEBUG_LEVEL DEBUG_APP_TRACE  */
 
 /* The line below, if defined, will only indicate test values on the display.
 this is for testing purposes only until I can get the PebbleKit.JS code operating with the emulator.
@@ -81,33 +81,6 @@ Make sure you udefine this before building a release.
 #define SET_BOLD_TIMEAGO		114	// Setting key - Meke the TimeAgo text bold if true
 #define SET_BOTTOM_LEFT_TEXT	        115	// Setting key - What to display in the bottom left text field
 #define SET_BOTTOM_RIGHT_TEXT	        116	// Setting key - What to display in the bottom right text field
-#define SET_USE_PNG             117
-#define SET_SHOW_UNIT           118
-#define SET_SHOW_DELTA          119
-#define SET_SHOW_SLOPE          120
-#define SET_SHOW_TREND          121
-#define SET_BGL_CRITICAL_COLOUR  301
-#define SET_BGL_HIGH_COLOUR      302
-#define SET_BGL_AVERAGE_COLOUR   303
-#define SET_BGL_GOOD_COLOUR      304
-#define SET_BGL_LOW_COLOUR       305
-#define SET_BGL_LOW             306
-#define SET_BGL_AVERAGE         307
-#define SET_BGL_HIGH            308
-#define SET_BGL_CRITICAL        309
-#define SET_LOW_LINE_COLOUR      310
-#define SET_HIGH_LINE_COLOUR     311
-#define SET_LINE_STYLE          312
-#define SET_LINE_WIDTH          313
-#define SET_TREND_STYLE         314
-#define SET_TREND_WIDTH         315
-#define SET_HIGH_LIMIT          316
-#define SET_HIGH_LINE_VALUE     317
-#define SET_LOW_LIMIT           318
-#define SET_LOW_LINE_VALUE      319
-#define SET_HOUR_ENABLED        320
-#define SET_HOUR_WIDTH          321
-#define SET_HOUR_STYLE          322
 #define CGM_SYNC_KEY			1000	// key pebble will use to request an update.	This should probably include the "capabilities" bits
 #define PBL_PLATFORM			1001	// key pebble will use to send it's platform	This is probably not required under the new famework.
 #define PBL_APP_VER			1002	// key pebble will use to send the face/app version.	This is probably not required under the new framework.

--- a/src/js/config.json
+++ b/src/js/config.json
@@ -484,6 +484,13 @@
               "min": 1,
               "max": 4,
               "group": "trend_hours"
+          },
+          {
+              "type": "toggle",
+              "messageKey": "trend_auto_adjust_max",
+              "label": "Auto-scale the maximum height of the graph",
+              "default": false,
+              "description": "If enabled the highest will be the highest bgl value or the high-line + 5%, else it will use the xdrip values." 
           }
       ]
   },

--- a/src/js/custom.js
+++ b/src/js/custom.js
@@ -24,8 +24,8 @@ module.exports = function(minified) {
             'trend_style',
             "trend_hour",
             "trend_hour_width",
-            "trend_hour_style"
-            
+            "trend_hour_style",
+            "trend_auto_adjust_max"            
         ];
         if (this.get()) {
             for (const index in items) {

--- a/src/js/custom.js
+++ b/src/js/custom.js
@@ -62,6 +62,7 @@ module.exports = function(minified) {
 
         var usepng = clayConfig.getItemByMessageKey('use_png');
         usepng.on('change', show_hide_trend);
+        usepng.trigger('change');
 
         // convert function
         var convert_bgl = function () {


### PR DESCRIPTION
This fix will very likely fix the problem where the watch face cannot send any data anymore and only receive.

* Fixes app meessage error state:
  * Forced error reporting on app message failures to make debugging with end users easier
  * Moved `app_message_outbox_begin` to after the bluetooth early escape since it is likely the cause of getting the AppMessage factory into the wrong state which is unfortunately unrecoverable if the iterator has been initialized and lost as it can only be fixed by calling the `app_message_outbox _send` function on the original iterator.
  * The failure handler was allowed to open a new appmessage but not send it, this allowed the app message state to become "invalid" with no means of recovery due to the lack of exposed functions in the SDK to be able to reset the state (you cannot close the app_message handlers and restart them).
  * Force the `send_cmd_cgm` to always finish to possibly fix a broken state. (this is far from guaranteed as there are many exit clauses allowing state transitions to become dead ends)
* Fixes bug where the clay settings would not hide settings if PNG was eelected
* Fixes bug where you could not switch from rendered to png and back without resetting the watch face
* Fixes bug where TEST_MODE was enabled
* Fixes bug where aplite would not draw trend series
* Fixes bug where the pushed bgl values from xdrip would be off by one

I have the strong suspicion the app message send state bug is only present on the coredevices watches and not the old ones but this change should fix it either way.

This also fixes the stupid error I made by committing the xDrip.h putting it in TEST_MODE ... 