### PR TITLE
Layer code update, moved debug values to debug.h and bugfixes

### DIFF
--- a/src/c/api/communication.h
+++ b/src/c/api/communication.h
@@ -80,20 +80,20 @@ typedef struct comm_bgl_value_t {
 
 typedef struct comm_bgl_data_t {
     uint32_t        timestamp;      // timestamp of bgl value
-    comm_bgl_value  bgl;
+    comm_bgl_value  bgl;            // bgl value
 } comm_bgl_data;
 
 typedef union  comm_bgl_delta_t {
     struct {
-        int8_t          value;
+        int8_t          value;              // bgl delta in mg/dl
         uint8_t : 3;
-        uint8_t         expired : 1;
-        uint8_t         hidden : 1;
-        uint8_t         undefined : 1; 
-        uint8_t         display_units : 1;
-        uint8_t         is_mmol : 1;
+        uint8_t         expired : 1;        // Sensor is expired
+        uint8_t         hidden : 1;         // BGL value is hidden (xDrip+ setting)
+        uint8_t         undefined : 1;      // BGL value is undefined, this is usualy a warming up sensor
+        uint8_t         display_units : 1;  // Display mmol/l or mg/dl
+        uint8_t         is_mmol : 1;        // Value should be displayed in mmol/l
     };
-    uint16_t raw;
+    uint16_t raw;                           // convenience blob
 } comm_bgl_delta;
 
 typedef struct comm_bgl_series_t {
@@ -102,42 +102,45 @@ typedef struct comm_bgl_series_t {
     comm_bgl_value  bgl_values[];   // open ended array of values
 } comm_bgl_series;
 
-typedef uint8_t comm_phonebat;
+typedef uint8_t comm_phonebat;      // Phone battery in percent
 
 typedef struct comm_message_t {
-    uint32_t length;
-    char    *message;
+    uint32_t length;        // Length of the message
+    char    *message;       // Message, MUST BE A UTF-8 encoded null terminated cstring
 } comm_message;
 
 typedef union  {
     struct {
-        uint16_t high_line;
-        uint16_t high_limit;
+        uint16_t high_line;     // High line value in mg/dl
+        uint16_t high_limit;    // High limit in mg/dl (usually either what user set or 400)
     };
-    uint32_t raw;
+    uint32_t raw;               // Convenience blob
 } comm_high_limit;
 typedef union {
     struct {
-        uint16_t low_line;
-        uint16_t low_limit;
+        uint16_t low_line;      // Low line value in mg/dl
+        uint16_t low_limit;     // Low limit in mg/dl (usually either what user set or 40)
     };
-    uint32_t raw;
+    uint32_t raw;               // Convenience blob
 } comm_low_limit;
-typedef uint8_t comm_vibe;
-typedef uint8_t comm_slopeval;
+typedef uint8_t comm_vibe;      // Vibate type 
+typedef uint8_t comm_slopeval;  // Slope icon value
 typedef struct {
-    uint16_t length;
-    uint8_t  *data;
+    uint16_t length;            // PNG data blob length
+    uint8_t  *data;             // PNG data blob
 } comm_png_data;
 
 
-typedef uint32_t comm_sensor_time_left;
-typedef uint32_t comm_bwp_value;
+typedef uint32_t comm_sensor_time_left; // Not implemented
+typedef uint32_t comm_bwp_value;        // Not implemented
 
 #pragma pack()
 
 /*
  * Callback struct
+ *
+ * All callbacks are registered on comm_init, this way a user
+ * can provide which to support and all others are ignored
  */
 typedef struct comm_callback_t {
     void (*phonebat)(comm_phonebat value);
@@ -156,8 +159,18 @@ typedef struct comm_callback_t {
     void (*png)(comm_png_data data);
 } comm_callback;
 
-
+/**
+ * Initialize the comms with a callback function blob
+ */
 void comm_init(comm_callback *cb);
+
+/**
+ * Handle a tuple of data, place this in the app mesage processing thread or function
+ */
 void comm_handle(Tuple *data);
+
+/**
+ * Request a png of a specific size
+ */
 void comm_request_png(DictionaryIterator *iter, GRect bounds);
 #endif // __COMMUNICATION_H__

--- a/src/c/api/trend.h
+++ b/src/c/api/trend.h
@@ -3,7 +3,29 @@
 
 #include <pebble.h>
 #include "communication.h"
-
+/**
+ * This is an example, values can be set to whatever suits your need
+ * + -> value <= BGL_LOW
+ * = -> BGL_LOW < value <= BGL_AVERAGE  
+ * * -> BGL_AVERAGE < value <= BGL_HIGH
+ * ^ -> BGL_HIGH < value <= BGL_CRITICAL
+ * # -> value > BGL_CRITICAL
+ *                            
+ *  ----------------------------##---       -> High limit, CRICICAL_COLOUR (top of layer)
+ *                            ##            -> BGL_CRITICAL, CRITICAL_COLOUR
+ *  - - - - - - - - - - - - ^^- - - -       -> High line value, high line style, high line width, HIGH_COLOUR 
+ *                        ^^                -> BGL_HIGH, HIGH_COLOR
+ *                      **                  -> AVERAGE_COLOUR
+ *                   **                     -> AVERAGE_COLOUR
+ *                **                        -> AVERAGE_COLOUR
+ *             **                           -> BGL_AVERAGE, AVERAGE_COLOUR
+ *          ==                              -> GOOD_COLOUR
+ *       ==                                 -> GOOD_COLOUR
+ *     ==                                   -> BGL_LOW, GOOD_COLOUR
+ *  -++ - - - - - - - - - - - - - - -       -> Low line value, low line style, low line width, LOW_COLOUR
+ *  +                                       -> LOW_COLOUR
+ *  ---------------------------------       -> Low limit (bottom of layer)
+ */
 
 /*
  * Settings from clay

--- a/src/c/api/trend.h
+++ b/src/c/api/trend.h
@@ -8,97 +8,100 @@
 /*
  * Settings from clay
  */
-#define SET_USE_PNG             117
-#define SET_SHOW_UNIT           118
-#define SET_SHOW_DELTA          119
-#define SET_SHOW_SLOPE          120
-#define SET_SHOW_TREND          121
-#define SET_BGL_CRITICAL_COLOUR  301
-#define SET_BGL_HIGH_COLOUR      302
-#define SET_BGL_AVERAGE_COLOUR   303
-#define SET_BGL_GOOD_COLOUR      304
-#define SET_BGL_LOW_COLOUR       305
-#define SET_BGL_LOW             306
-#define SET_BGL_AVERAGE         307
-#define SET_BGL_HIGH            308
-#define SET_BGL_CRITICAL        309
-#define SET_LOW_LINE_COLOUR      310
-#define SET_HIGH_LINE_COLOUR     311
-#define SET_LINE_STYLE          312
-#define SET_LINE_WIDTH          313
-#define SET_TREND_STYLE         314
-#define SET_TREND_WIDTH         315
-#define SET_HIGH_LIMIT          316
-#define SET_HIGH_LINE_VALUE     317
-#define SET_LOW_LIMIT           318
-#define SET_LOW_LINE_VALUE      319
-#define SET_HOUR_ENABLED        320
-#define SET_HOUR_WIDTH          321
-#define SET_HOUR_STYLE          322
-#define SET_AUTO_ADJUST_MAX     323
+#define SET_USE_PNG                 117     // Set the use of PNG images from xDrip or local rendered
+#define SET_SHOW_UNIT               118     // Show unit in delta screen    @deprecated
+#define SET_SHOW_DELTA              119     // Show the delta               @deprecated
+#define SET_SHOW_SLOPE              120     // Show the slope icon          @deprecated
+#define SET_SHOW_TREND              121     // Show the trend               @deprecated
+#define SET_BGL_CRITICAL_COLOUR     301     // Colour of the top of the trend line above SET_BGL_CRITICAL
+#define SET_BGL_HIGH_COLOUR         302     // Colour of the high part of the trend line between SET_BGL_HIGH and SET_BGL_CRITICAL
+#define SET_BGL_AVERAGE_COLOUR      303     // Colour of the middle part of the trend line between SET_BGL_AVERAGE and SET_BGL_HIGH
+#define SET_BGL_GOOD_COLOUR         304     // Colour of the "good" part of the trend line between SET_BGL_LOW and SET_BGL_AVERAGE
+#define SET_BGL_LOW_COLOUR          305     // Colour of the low part of the trend line below SET_BGL_LOW
+#define SET_BGL_LOW                 306     // Value below which LOW_COLOUR is valid
+#define SET_BGL_AVERAGE             307     // Value below which AVERAGE_COLOUR is valid
+#define SET_BGL_HIGH                308     // Value below which HIGH_COLOUR is valid
+#define SET_BGL_CRITICAL            309     // Value below which CRITICAL_COLOUR is valid
+#define SET_LOW_LINE_COLOUR         310     // Colour of the low line if enabled in xDrip
+#define SET_HIGH_LINE_COLOUR        311     // Colour of the high line if enabled in xDrip
+#define SET_LINE_STYLE              312     // Low and high line style (see trend_line_style)
+#define SET_LINE_WIDTH              313     // Width of the high and low line 
+#define SET_TREND_STYLE             314     // Trend drawing style (see trend_style)
+#define SET_TREND_WIDTH             315     // Width of the trend items (e.g. line width or circle radius)
+#define SET_HIGH_LIMIT              316     // Highest displayable limit, set by xDrip
+#define SET_HIGH_LINE_VALUE         317     // High line value, set by xDrip
+#define SET_LOW_LIMIT               318     // Lowest displayable value, set by xDrip 
+#define SET_LOW_LINE_VALUE          319     // Low line value, set by xDrip
+#define SET_HOUR_ENABLED            320     // Enable hour line marks
+#define SET_HOUR_WIDTH              321     // Set width of hour lines
+#define SET_HOUR_STYLE              322     // Set hour style (see trend_line_style)
+#define SET_AUTO_ADJUST_MAX         323     // Enable auto-scaling
 
 #define TREND_LOG "TREND :: "
 
 typedef int16_t trend_bgl_value; 
 
+/*
+ * Unused since the trend line is a dimensionless value as no axis is present
+ */
 typedef enum {
     BGL_TYPE_MMOL_L = 0,
     BGL_TYPE_MG_DL = 1
 } bgl_type;
 
 typedef enum {
-    TREND_STYLE_DOTS = 0,
-    TREND_STYLE_LINES = 1
+    TREND_STYLE_DOTS = 0,       // Use dots/circles to draw the trend line 
+    TREND_STYLE_LINES = 1       // Use lines to draw the trend line
 } trend_style;
 
 typedef enum {
-    TREND_LINE_STYLE_SOLID = 0,
-    TREND_LINE_STYLE_DOTTED,
-    TREND_LINE_STYLE_DOTTED_SPARSE,
-    TREND_LINE_STYLE_DASHED,
-    TREND_LINE_STYLE_DASHED_WIDE,
-    TREND_LINE_STYLE_EDGES,
+    TREND_LINE_STYLE_SOLID = 0,             // Solid line
+    TREND_LINE_STYLE_DOTTED,                // Dots with equal spaceing (2px)
+    TREND_LINE_STYLE_DOTTED_SPARSE,         // Dots with larger spacing (4px)
+    TREND_LINE_STYLE_DASHED,                // Dashes in repeating pattern
+    TREND_LINE_STYLE_DASHED_WIDE,           // Dashes both wider and more spaced
+    TREND_LINE_STYLE_EDGES,                 // Edge marks (20% of left/right or top/bottom)
 } trend_line_style;
 
 typedef struct {
-    int8_t  initialized;
-    int16_t size;
-    int16_t index;
-    int8_t  hours;
-    trend_bgl_value values[PBL_DISPLAY_WIDTH]; // maximum
+    int8_t  initialized;                    // 0 if no series received, 1 afterwards 
+    int16_t size;                           // Actual size of series (depends on update rate and hours) 
+    int16_t index;                          // Current index of the series 
+    int8_t  hours;                          // Number of hours displayed
+    trend_bgl_value values[PBL_DISPLAY_WIDTH]; // Values, maximum is the display width
 } bgl_array;
 
 
 typedef struct {
-    bgl_type    bgl_type;           // Value style, no function as of yet 
-    GColor      critical_color;     // Colour for critically high trend
-    GColor      high_color;         // Colour for high trend
-    GColor      average_color;      // Colour for average trend 
-    GColor      good_color;         // Colour for good trend
-    GColor      low_color;          // Colour for low trend
-    GColor      high_line_color;    // Colour of high line
-    GColor      low_line_color;     // Colour of low line
-    GColor      hour_line_color;
-    int8_t      hour_line_width;
-    int8_t      hour_line_enabled : 1;
-    int8_t      auto_adjust_max : 1;
+    bgl_type    bgl_type;               // Value style, no function as of yet 
+    GColor      critical_color;         // Colour for critically high trend
+    GColor      high_color;             // Colour for high trend
+    GColor      average_color;          // Colour for average trend 
+    GColor      good_color;             // Colour for good trend
+    GColor      low_color;              // Colour for low trend
+    GColor      high_line_color;        // Colour of high line
+    GColor      low_line_color;         // Colour of low line
+    GColor      hour_line_color;        // Colour of the hour lines, currently fixed
+    int8_t      hour_line_width;        // Width of the hour lines
+    int8_t      hour_line_enabled : 1;  // Enable / disable hour lines
+    int8_t      auto_adjust_max : 1;    // Enable / disable auto-adjust
     int8_t      : 6;
-    int8_t      line_width;         // High/low line width
-    int8_t      trend_width;        // Trend line width
-    int16_t     bgl_low;            // Low value
-    int16_t     bgl_average;        // Average value
-    int16_t     bgl_high;           // High value
-    int16_t     bgl_critical;       // Critical value
-    int16_t     bgl_high_line;      // High line value
-    int16_t     bgl_low_line;       // Low line value
-    int16_t     bgl_high_limit;     // Gigh graph limit
-    int16_t     bgl_low_limit;      // Low graph limit 
-    Layer       *layer;             // Layer to draw into
-    bgl_array   bgl;                // Storage for BGL values
-    trend_style style;              // Trend line style
-    trend_line_style hl_line_style;    // High/low line style
-    trend_line_style hour_line_style;
-    int8_t      redraw;             // Redraw value (not really working right now)
+    int8_t      line_width;             // High/low line width
+    int8_t      trend_width;            // Trend line width
+    int16_t     bgl_low;                // Low value
+    int16_t     bgl_average;            // Average value
+    int16_t     bgl_high;               // High value
+    int16_t     bgl_critical;           // Critical value
+    int16_t     bgl_high_line;          // High line value
+    int16_t     bgl_low_line;           // Low line value
+    int16_t     bgl_high_limit;         // Gigh graph limit
+    int16_t     bgl_low_limit;          // Low graph limit 
+    Layer       *layer;                 // Layer to draw into
+    bgl_array   bgl;                    // Storage for BGL values
+    trend_style style;                  // Trend line style
+    trend_line_style hl_line_style;     // High/low line style
+    trend_line_style hour_line_style;   // Hour line style
+    int8_t      redraw;                 // Redraw value (not really working right now)
 } trend_config;
 
 /**
@@ -106,28 +109,58 @@ typedef struct {
  *
  * @param Layer to draw in to
  */
+
+/**
+ * Initialize the trend line, layer MUST be a drawable layer (e.g. bitmap layer)
+ * @param layer     The layer to draw into
+ */
 void trend_init(Layer *layer);
+
+/**
+ * Deinit the trend line, note: due to how pebbleos works the update_proc
+ * cannot be restored to the original value. Therefore a bitmap cannot be updated
+ * with a PNG after using it as a trend line drawing.
+ */
 void trend_deinit(void);
 
 /**
- * Forse a redraw
+ * Forse a redraw of the trend line, this will mark the layer dirty
  */
 void trend_draw(void);
 
 /**
  * Function to handle config items passed as tuples by the pebble app
+ * Call this function in your app message processing thread
+ *
+ * @param data  The tuple to process
  */
 void trend_process_config(Tuple *data);
 
 /**
  * Callback function to set the bgl series to use for drawing the trend line
+ *
+ * If this function is called for the first time it will set the size of the trend line.
+ * @param values    The trend line values from xDrip+
  */
 void trend_set_series(comm_bgl_series *values); 
 /**
  * Callback function to add a single value to the bgl trend line
+ *
+ * @param value     The value to add
  */
 void trend_set_value(comm_bgl_data *value);
+/**
+ * Set the high line and global high limit
+ *
+ * @param value     The value from xDrip+
+ */
 void trend_set_high_line(comm_high_limit value);
+
+/**
+ * Set the low line and global low limit
+ *
+ * @param value     The value from xDrip+
+ */
 void trend_set_low_line(comm_low_limit value);
 
 int trend_isinitialized(void);

--- a/src/c/debug.h
+++ b/src/c/debug.h
@@ -4,7 +4,27 @@
  * Debug helper macros
  */
 
-// Scope debug to cleanup debug ifdefs
+/**
+ * Defines for testing modes
+ */
+
+/* The line below, if defined, will only indicate test values on the display.
+this is for testing purposes only until I can get the PebbleKit.JS code operating with the emulator.
+Make sure you udefine this before building a release.
+*/
+/* #define TEST_MODE */
+
+
+/*
+ * Set debug text to show and compile DEBUG_APP_[NONE,INFO,DEBUG,TRACE]
+ * Note: Aplite will not go above INFO logging.
+ */
+#define DEBUG_APP_TRACE 3
+#define DEBUG_APP_DEBUG 2
+#define DEBUG_APP_INFO 1
+#define DEBUG_APP_NONE 0
+
+/* #define DEBUG_LEVEL DEBUG_APP_TRACE  */
 
 /*  
  *  The line below will set the debug message level.

--- a/src/c/xdrip.c
+++ b/src/c/xdrip.c
@@ -2432,23 +2432,13 @@ void window_load_cgm(Window *window_cgm)
 	// DELTA BG
 	LOG("Creating Delta BG Text layer");
 	text_layer_set_font(delta_layer, fonts_get_system_font(FONT_KEY_GOTHIC_28));
-#ifdef TEST_MODE
-	text_layer_set_text(delta_layer,"0.5mmol");
-#endif
-
 
 	// MESSAGE
 	LOG("Creating Message Text layer");
-#ifdef TEST_MODE
-	snprintf(message_layer_text,sizeof(message_layer_text), "Test Mode");
-	text_layer_set_text(message_layer, message_layer_text);
-	display_message=true;
-	layer_set_hidden((Layer *)message_layer, true);
-#else
 	snprintf(message_layer_text,sizeof(message_layer_text),"%s","");
 	text_layer_set_text(message_layer, message_layer_text);
 	layer_set_hidden((Layer *)message_layer, true);
-#endif
+
 	// BG
 	LOG("Creating BG Text layer");
 
@@ -2521,6 +2511,12 @@ void window_load_cgm(Window *window_cgm)
 	last_battlevel = 100;
 	current_icon = 1;
 	specvalue_alert=false;
+
+	snprintf(message_layer_text,sizeof(message_layer_text), "Test Mode");
+	text_layer_set_text(message_layer, message_layer_text);
+	display_message=true;
+	layer_set_hidden((Layer *)message_layer, true);
+	text_layer_set_text(delta_layer,"0.5mmol");
 #endif
     LOG("Setting display values to correct state");
 	draw_date_from_app();
@@ -2540,8 +2536,6 @@ void window_load_cgm(Window *window_cgm)
 	text_layer_set_text_alignment(message_layer, GTextAlignmentCenter);
 #endif
 
-//	TRACE("WINDOW LOAD, ABOUT TO CALL APP SYNC INIT");
-	//app_sync_init(&sync_cgm, sync_buffer_cgm, sizeof(sync_buffer_cgm), initial_values_cgm, ARRAY_LENGTH(initial_values_cgm), sync_tuple_changed_callback_cgm, sync_error_callback_cgm, NULL);
 	// init timer to null if needed, and register timer
 	TRACE("window_load_cgm: build done, init timer");
     // mark dirty and request data

--- a/src/c/xdrip.c
+++ b/src/c/xdrip.c
@@ -2096,16 +2096,16 @@ void window_load_cgm(Window *window_cgm)
 	cgmtime_layer = text_layer_create(GRect(104, 58, 40, 24));
 	text_layer_set_text_alignment(cgmtime_layer, GTextAlignmentRight);
 	// time watch layer dimenssions
-	time_watch_layer = text_layer_create(GRect(0, 84, 143, 44));
+	time_watch_layer = text_layer_create(GRect(0, 84 - 89, 143, 44));
 	text_layer_set_text_alignment(time_watch_layer, GTextAlignmentCenter);
 	// date layer dimenstions
-	date_app_layer = text_layer_create(GRect(0, 124, 143, 29));
+	date_app_layer = text_layer_create(GRect(0, 124 - 89, 143, 29));
 	text_layer_set_text_alignment(date_app_layer, GTextAlignmentCenter);
 	// phone/bridge batter level layer diemnsions
-	bottom_left_text_layer = text_layer_create(GRect(0, 148, 59, 18));
+	bottom_left_text_layer = text_layer_create(GRect(0, 148 - 89, 59, 18));
 	text_layer_set_text_alignment(bottom_left_text_layer, GTextAlignmentLeft);
 	//watch battery level layer dimensions
-	bottom_right_text_layer = text_layer_create(GRect(81, 148, 59, 18));
+	bottom_right_text_layer = text_layer_create(GRect(81, 148 - 89, 59, 18));
 	text_layer_set_text_alignment(bottom_right_text_layer, GTextAlignmentRight);
 
 #endif
@@ -2142,17 +2142,17 @@ void window_load_cgm(Window *window_cgm)
 	layer_set_bounds((Layer *) cgmtime_layer, GRect(0, -2, 40, 24)); // fixes bounding box with latest sdk
 	text_layer_set_text_alignment(cgmtime_layer, GTextAlignmentRight);
 	// time watch layer dimenssions
-	time_watch_layer = text_layer_create(GRect(0, 82, 143, 44));
+	time_watch_layer = text_layer_create(GRect(0, 82 - 84, 143, 44));
 	text_layer_set_text_alignment(time_watch_layer, GTextAlignmentCenter);
 	// date layer dimenstions
-	date_app_layer = text_layer_create(GRect(0, 124, 143, 29));
+	date_app_layer = text_layer_create(GRect(0, 124 - 84, 143, 29));
 	text_layer_set_text_alignment(date_app_layer, GTextAlignmentCenter);
 	// phone/bridge batter level layer diemnsions
-	bottom_left_text_layer = text_layer_create(GRect(0, 148, 72, 20));
+	bottom_left_text_layer = text_layer_create(GRect(0, 148 - 84, 72, 20));
 	layer_set_bounds((Layer *) bottom_left_text_layer, GRect(0, -1, 72, 20)); // fixes bounding box with latest sdk
 	text_layer_set_text_alignment(bottom_left_text_layer, GTextAlignmentLeft);
 	// watch battery level layer dimensions
-	bottom_right_text_layer = text_layer_create(GRect(72, 148, 72, 20));
+	bottom_right_text_layer = text_layer_create(GRect(72, 148 - 84, 72, 20));
 	layer_set_bounds((Layer *) bottom_right_text_layer, GRect(0, -1, 72, 20)); // fixes bounding box with latest sdk
 	text_layer_set_text_alignment(bottom_right_text_layer, GTextAlignmentRight);
 
@@ -2188,16 +2188,16 @@ void window_load_cgm(Window *window_cgm)
 	cgmtime_layer = text_layer_create(GRect(5, 58, 40, 24));
 	text_layer_set_text_alignment(cgmtime_layer, GTextAlignmentRight);
 	// time watch layer dimenssions
-	time_watch_layer = text_layer_create(GRect(18, 82, 143, 44));
+	time_watch_layer = text_layer_create(GRect(18, 82 - 84, 143, 44));
 	text_layer_set_text_alignment(time_watch_layer, GTextAlignmentCenter);
 	// date layer dimenstions
-	date_app_layer = text_layer_create(GRect(18, 124, 143, 26));
+	date_app_layer = text_layer_create(GRect(18, 124 - 84, 143, 26));
 	text_layer_set_text_alignment(date_app_layer, GTextAlignmentCenter);
 	// phone/bridge batter level layer diemnsions
-	bottom_left_text_layer = text_layer_create(GRect(48, 150, 1, 1));
+	bottom_left_text_layer = text_layer_create(GRect(48, 150 - 84, 1, 1));
 	text_layer_set_text_alignment(bottom_left_text_layer, GTextAlignmentLeft);
 	// watch battery level layer dimensions
-	bottom_right_text_layer = text_layer_create(GRect(45, 150, 90, 18));
+	bottom_right_text_layer = text_layer_create(GRect(45, 150 - 84, 90, 18));
 	text_layer_set_text_alignment(bottom_right_text_layer, GTextAlignmentCenter);
 
 #endif
@@ -2229,16 +2229,16 @@ void window_load_cgm(Window *window_cgm)
 	cgmtime_layer = text_layer_create(GRect(104, 58, 40, 24));
 	text_layer_set_text_alignment(cgmtime_layer, GTextAlignmentRight);
 	// time watch layer dimenssions
-	time_watch_layer = text_layer_create(GRect(0, 84, 143, 44));
+	time_watch_layer = text_layer_create(GRect(0, 84 - 89, 143, 44));
 	text_layer_set_text_alignment(time_watch_layer, GTextAlignmentCenter);
 	// date layer dimenstions
-	date_app_layer = text_layer_create(GRect(0, 124, 143, 29));
+	date_app_layer = text_layer_create(GRect(0, 124 - 89, 143, 29));
 	text_layer_set_text_alignment(date_app_layer, GTextAlignmentCenter);
 	// phone/bridge batter level layer diemnsions
-	bottom_left_text_layer = text_layer_create(GRect(0, 148, 59, 18));
+	bottom_left_text_layer = text_layer_create(GRect(0, 148 - 89, 59, 18));
 	text_layer_set_text_alignment(bottom_left_text_layer, GTextAlignmentLeft);
 	// watch battery level layer dimensions
-	bottom_right_text_layer = text_layer_create(GRect(81, 148, 59, 18));
+	bottom_right_text_layer = text_layer_create(GRect(81, 148 - 89, 59, 18));
 	text_layer_set_text_alignment(bottom_right_text_layer, GTextAlignmentRight);
 
 #endif
@@ -2270,23 +2270,23 @@ void window_load_cgm(Window *window_cgm)
 	text_layer_set_text_alignment(cgmtime_layer, GTextAlignmentRight);
 	// time watch layer dimenssions
 	if (display_seconds) {
-		time_watch_layer = text_layer_create(GRect(0, 121, 200, 60));
+		time_watch_layer = text_layer_create(GRect(0, 121 - 115., 200, 60));
 	} else {
-		time_watch_layer = text_layer_create(GRect(0, 111, 200, 60));
+		time_watch_layer = text_layer_create(GRect(0, 111 - 115, 200, 60));
 	}
 	text_layer_set_text_alignment(time_watch_layer, GTextAlignmentCenter);
 	// date layer dimenstions
 	if (display_seconds) {
-		date_app_layer = text_layer_create(GRect(0, 168, 200, 39));
+		date_app_layer = text_layer_create(GRect(0, 168 - 115, 200, 39));
 	} else {
-		date_app_layer = text_layer_create(GRect(0, 176, 200, 39));
+		date_app_layer = text_layer_create(GRect(0, 176 - 115, 200, 39));
 	}
 	text_layer_set_text_alignment(date_app_layer, GTextAlignmentCenter);
 	// phone/bridge batter level layer diemnsions
-	bottom_left_text_layer = text_layer_create(GRect(2, 203, 100, 24));
+	bottom_left_text_layer = text_layer_create(GRect(2, 203 - 115, 100, 24));
 	text_layer_set_text_alignment(bottom_left_text_layer, GTextAlignmentLeft);
 	// watch battery level layer dimensions
-	bottom_right_text_layer = text_layer_create(GRect(98, 203, 100, 24));
+	bottom_right_text_layer = text_layer_create(GRect(98, 203 - 115, 100, 24));
 	text_layer_set_text_alignment(bottom_right_text_layer, GTextAlignmentRight);
 
 #endif
@@ -2319,16 +2319,16 @@ void window_load_cgm(Window *window_cgm)
 	cgmtime_layer = text_layer_create(GRect(104, 58, 40, 24));
 	text_layer_set_text_alignment(cgmtime_layer, GTextAlignmentRight);
 	// time watch layer dimenssions
-	time_watch_layer = text_layer_create(GRect(0, 84, 143, 44));
+	time_watch_layer = text_layer_create(GRect(0, 84 - 89, 143, 44));
 	text_layer_set_text_alignment(time_watch_layer, GTextAlignmentCenter);
 	// date layer dimenstions
-	date_app_layer = text_layer_create(GRect(0, 124, 143, 29));
+	date_app_layer = text_layer_create(GRect(0, 124 - 89, 143, 29));
 	text_layer_set_text_alignment(date_app_layer, GTextAlignmentCenter);
 	// phone/bridge batter level layer diemnsions
-	bottom_left_text_layer = text_layer_create(GRect(0, 148, 59, 18));
+	bottom_left_text_layer = text_layer_create(GRect(0, 148 - 89, 59, 18));
 	text_layer_set_text_alignment(bottom_left_text_layer, GTextAlignmentLeft);
 	// watch battery level layer dimensions
-	bottom_right_text_layer = text_layer_create(GRect(81, 148, 59, 18));
+	bottom_right_text_layer = text_layer_create(GRect(81, 148 - 89, 59, 18));
 	text_layer_set_text_alignment(bottom_right_text_layer, GTextAlignmentRight);
 
 #endif
@@ -2365,16 +2365,16 @@ void window_load_cgm(Window *window_cgm)
 	cgmtime_layer = text_layer_create(GRect(  7,  84,  58,  35));
 	text_layer_set_text_alignment(cgmtime_layer, GTextAlignmentRight);
 	// time watch layer dimenssions
-	time_watch_layer = text_layer_create(GRect( 26, 118, 206,  64));
+	time_watch_layer = text_layer_create(GRect( 26, 118 - 121, 206,  64));
 	text_layer_set_text_alignment(time_watch_layer, GTextAlignmentCenter);
 	// date layer dimenstions
-	date_app_layer = text_layer_create(GRect( 26, 178, 206,  38));
+	date_app_layer = text_layer_create(GRect( 26, 178 - 121, 206,  38));
 	text_layer_set_text_alignment(date_app_layer, GTextAlignmentCenter);
 	// phone/bridge batter level layer diemnsions
-	bottom_left_text_layer = text_layer_create(GRect( 69, 236,  130,  26));
+	bottom_left_text_layer = text_layer_create(GRect( 69, 236 - 121,  130,  26));
 	text_layer_set_text_alignment(bottom_left_text_layer, GTextAlignmentLeft);
 	// watch battery level layer dimensions
-	bottom_right_text_layer = text_layer_create(GRect( 65, 210,  130,  26));
+	bottom_right_text_layer = text_layer_create(GRect( 65, 210 - 121,  130,  26));
 	text_layer_set_text_alignment(bottom_right_text_layer, GTextAlignmentCenter);
 
 #endif
@@ -2421,32 +2421,16 @@ void window_load_cgm(Window *window_cgm)
 	
 	//Paint the backgrounds for upper and lower halves of the watch face.
 	LOG("Creating Upper and Lower face panels");
-	layer_add_child(window_layer_cgm, bitmap_layer_get_layer(upper_face_layer));
-	layer_add_child(window_layer_cgm, bitmap_layer_get_layer(lower_face_layer));
-
-
 
 	//create the bg_trend_layer
 	INFO("Creating BG Trend Bitmap layer");
-#if DEBUG_LEVEL > 0
-	text_layer_set_background_color(message_layer, GColorClear);
-	text_layer_set_font(message_layer, fonts_get_system_font(FONT_KEY_GOTHIC_28));
-	text_layer_set_text_alignment(message_layer, GTextAlignmentCenter);
-#endif
 
-	layer_add_child(window_layer_cgm, bitmap_layer_get_layer(bg_trend_layer_png));
-	layer_add_child(window_layer_cgm, bitmap_layer_get_layer(bg_trend_layer_draw));
 
     layer_set_hidden(bitmap_layer_get_layer(bg_trend_layer_png), !use_png);
     layer_set_hidden(bitmap_layer_get_layer(bg_trend_layer_draw), use_png);
 
 	// ARROW OR SPECIAL VALUE
 	LOG("Creating Arrow Bitmap layer");
-#if defined(PBL_PLATFORM_EMERY) || defined(PBL_PLATFORM_GABBRO)
-	layer_add_child(window_layer_cgm, bitmap_layer_get_layer(icon_layer));
-#else
-	layer_add_child(window_layer_cgm, bitmap_layer_get_layer(icon_layer));
-#endif
 
 	// DELTA BG
 	LOG("Creating Delta BG Text layer");
@@ -2455,7 +2439,6 @@ void window_load_cgm(Window *window_cgm)
 	text_layer_set_text(delta_layer,"0.5mmol");
 #endif
 
-	layer_add_child(window_layer_cgm, text_layer_get_layer(delta_layer));
 
 	// MESSAGE
 	LOG("Creating Message Text layer");
@@ -2464,89 +2447,101 @@ void window_load_cgm(Window *window_cgm)
 	text_layer_set_text(message_layer, message_layer_text);
 	display_message=true;
 	layer_set_hidden((Layer *)message_layer, true);
-	layer_add_child(window_layer_cgm, text_layer_get_layer(message_layer));
 #else
 	snprintf(message_layer_text,sizeof(message_layer_text),"%s","");
 	text_layer_set_text(message_layer, message_layer_text);
 	layer_set_hidden((Layer *)message_layer, true);
-	layer_add_child(window_layer_cgm, text_layer_get_layer(message_layer));
 #endif
 	// BG
 	LOG("Creating BG Text layer");
-	layer_add_child(window_layer_cgm, text_layer_get_layer(bg_layer));
-
 
 	// CGM TIME AGO READING
 	LOG("Creating CGM Time Ago Bitmap layer");
-	layer_add_child(window_layer_cgm, text_layer_get_layer(cgmtime_layer));
-
 
 	// CURRENT ACTUAL TIME FROM WATCH
 	LOG("Creating Watch Time Text layer");
-//	text_layer_set_text_alignment(time_watch_layer, GTextAlignmentCenter);
-	layer_add_child(window_layer_cgm, text_layer_get_layer(time_watch_layer));
 
 	// CURRENT ACTUAL DATE FROM APP
 	LOG("Creating Watch Date Text layer");
-//	date_app_layer = text_layer_create(GRect(0, 122, 143, 29));
 	text_layer_set_text_color(date_app_layer, fg_colour);
 	text_layer_set_background_color(date_app_layer, GColorClear);
 	text_layer_set_font(date_app_layer, fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD));
-	//text_layer_set_text_alignment(date_app_layer, GTextAlignmentCenter);
-	layer_add_child(window_layer_cgm, text_layer_get_layer(date_app_layer));
-	draw_date_from_app();
 
 	// Metric Layers
 	// left metric layer
 	LOG("Creating Left Metric Text layer");
-//	text_layer_set_text_color(bottom_left_text_layer, GColorGreen);
 	text_layer_set_text_color(bottom_left_text_layer, fg_colour);
 	text_layer_set_background_color(bottom_left_text_layer, GColorClear);
 	text_layer_set_font(bottom_left_text_layer, fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD));
-	layer_add_child(window_layer_cgm, text_layer_get_layer(bottom_left_text_layer));
-	//LOG("bottom_left_text_layer; %s", text_layer_get_text(bottom_left_text_layer));
 
 	// right metric layer
 	LOG("Creating Right Metric Text layer");
-//	text_layer_set_text_color(bottom_right_text_layer, GColorGreen);
 	text_layer_set_text_color(bottom_right_text_layer, fg_colour);
 	text_layer_set_background_color(bottom_right_text_layer, GColorClear);
 	text_layer_set_font(bottom_right_text_layer, fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD));
-	layer_add_child(window_layer_cgm, text_layer_get_layer(bottom_right_text_layer));
 
-	// prep for battery display, even if we don't have one.
-	BatteryChargeState charge_state=battery_state_service_peek();
-	battery_handler(charge_state);
-	
+    // Layer definitions
+    LOG("Setting Layer order");
+
+    // bg's
+	layer_add_child(window_layer_cgm, bitmap_layer_get_layer(upper_face_layer));
+	layer_add_child(window_layer_cgm, bitmap_layer_get_layer(lower_face_layer));
+
+    // trend layers
+    layer_add_child(bitmap_layer_get_layer(upper_face_layer), bitmap_layer_get_layer(bg_trend_layer_png));
+    layer_insert_above_sibling(bitmap_layer_get_layer(bg_trend_layer_draw), bitmap_layer_get_layer(bg_trend_layer_png));
+
+    // top
+    layer_insert_above_sibling(bitmap_layer_get_layer(icon_layer), bitmap_layer_get_layer(bg_trend_layer_draw));
+    layer_insert_above_sibling(text_layer_get_layer(delta_layer), bitmap_layer_get_layer(bg_trend_layer_draw));
+    layer_insert_above_sibling(text_layer_get_layer(message_layer), bitmap_layer_get_layer(bg_trend_layer_draw));
+    layer_insert_above_sibling(text_layer_get_layer(bg_layer), bitmap_layer_get_layer(bg_trend_layer_draw));
+    layer_insert_above_sibling(text_layer_get_layer(cgmtime_layer), bitmap_layer_get_layer(bg_trend_layer_draw));
+
+    // bottom
+    layer_add_child(bitmap_layer_get_layer(lower_face_layer), text_layer_get_layer(time_watch_layer));
+    layer_insert_above_sibling(text_layer_get_layer(date_app_layer), text_layer_get_layer(time_watch_layer));
+    layer_insert_above_sibling(text_layer_get_layer(bottom_left_text_layer), text_layer_get_layer(time_watch_layer));
+    layer_insert_above_sibling(text_layer_get_layer(bottom_right_text_layer), text_layer_get_layer(time_watch_layer));
+
+    if (!use_png) trend_init(bitmap_layer_get_layer(bg_trend_layer_draw));
+
 	// put " " (space) in bg field so logo continues to show
 	// " " (space) also shows these are init values, not bad or null values
+    // Setting all default values here
+
+	// prep for battery display, even if we don't have one.
+	BatteryChargeState charge_state = battery_state_service_peek();
 	current_icon = 255; // no icon set and ignore
+	snprintf(last_bg, BG_MSGSTR_SIZE, " ");
+	current_cgm_time = 0;
+	current_app_time = 0;
+	snprintf(current_bg_delta, BGDELTA_MSGSTR_SIZE, "LOAD");
+	last_battlevel = 255;
+
 #ifdef TEST_MODE
+	snprintf(current_bg_delta, BGDELTA_MSGSTR_SIZE, "+0.08");
+	last_battlevel = 100;
 	current_icon = 1;
 	specvalue_alert=false;
 #endif
-	load_icon();
-	snprintf(last_bg, BG_MSGSTR_SIZE, " ");
-	load_bg();
-	current_cgm_time = 0;
+    LOG("Setting display values to correct state");
+	draw_date_from_app();
+	battery_handler(charge_state);
 	load_cgmtime();
-	current_app_time = 0;
-	snprintf(current_bg_delta, BGDELTA_MSGSTR_SIZE, "LOAD");
-//if it is not for a COLOR platform, it is monochrome
-	//text_layer_set_text_alignment(cgmtime_layer, GTextAlignmentRight);
-	//text_layer_set_text_alignment(cgmtime_layer, GTextAlignmentCenter);
-#ifdef TEST_MODE
-	snprintf(current_bg_delta, BGDELTA_MSGSTR_SIZE, "+0.08");
-#endif
+	load_bg();
+	load_icon();
 	load_bg_delta();
-	last_battlevel = 255;
-#ifdef TEST_MODE
-	last_battlevel = 100;
-#endif
 	load_battlevel();
 
-    // default config
-    if (!use_png) trend_init(bitmap_layer_get_layer(bg_trend_layer_draw));
+    layer_mark_dirty(text_layer_get_layer(bg_layer));
+
+
+#if DEBUG_LEVEL > 0
+	text_layer_set_background_color(message_layer, GColorClear);
+	text_layer_set_font(message_layer, fonts_get_system_font(FONT_KEY_GOTHIC_28));
+	text_layer_set_text_alignment(message_layer, GTextAlignmentCenter);
+#endif
 
 //	TRACE("WINDOW LOAD, ABOUT TO CALL APP SYNC INIT");
 	//app_sync_init(&sync_cgm, sync_buffer_cgm, sizeof(sync_buffer_cgm), initial_values_cgm, ARRAY_LENGTH(initial_values_cgm), sync_tuple_changed_callback_cgm, sync_error_callback_cgm, NULL);

--- a/src/c/xdrip.c
+++ b/src/c/xdrip.c
@@ -1193,19 +1193,16 @@ static void load_bg()
 		}
 	} 
 
-	else
-	{
-		TRACE("load_bg: AFTER CREATE SPEC VALUE BITMAP");
+    TRACE("load_bg: AFTER CREATE SPEC VALUE BITMAP");
+    // always trigger since we have a new value or need to draw
+    if (specvalue_alert == false)
+    {
+        // we didn't find a special value, so set BG instead
+        // arrow icon already set separately
+        TRACE("load_bg: SET BG: %s ", last_bg);
+        text_layer_set_text(bg_layer, last_bg);
+    } // end bg checks (if special_value_bitmap)
 
-		if (specvalue_alert == false)
-		{
-			// we didn't find a special value, so set BG instead
-			// arrow icon already set separately
-			TRACE("load_bg: SET BG: %s ", last_bg);
-			text_layer_set_text(bg_layer, last_bg);
-		} // end bg checks (if special_value_bitmap)
-
-	}
 
 	TRACE("load_bg: SNOOZE VALUE: %d", lastAlertTime);
 	LOG("load_bg: bg_layer is \"%s\"", text_layer_get_text(bg_layer));

--- a/src/c/xdrip.h
+++ b/src/c/xdrip.h
@@ -5,26 +5,6 @@
 #include <pebble.h>
 #include <math.h>
 #include "constant.h"
-/**
- * Defines for testing modes
- */
-
-/*
- * Set debug text to show and compile DEBUG_APP_[NONE,INFO,DEBUG,TRACE]
- * Note: Aplite will not go above INFO logging.
- */
-#define DEBUG_APP_TRACE 3
-#define DEBUG_APP_DEBUG 2
-#define DEBUG_APP_INFO 1
-#define DEBUG_APP_NONE 0
-
-/* #define DEBUG_LEVEL DEBUG_APP_TRACE  */
-
-/* The line below, if defined, will only indicate test values on the display.
-this is for testing purposes only until I can get the PebbleKit.JS code operating with the emulator.
-Make sure you udefine this before building a release.
-*/
-/* #define TEST_MODE */
 
 /**
  * Feature flags


### PR DESCRIPTION
* Redid layer code
 * The layers are now valid children, and thus should have less updates (e.g. minute change should not update the upper layer)
 * Lower layer values have valid offsets now and should show
 * All layers are marked as siblings to avoid them not getting drawn in their parent (upper or lower)
* Moved debug code to debug.h to avoid accidentally pushing it when changing xdrip.h
* Fixed bug where the BGL value would not draw on first load. This only happened on the png due to the order of the messages and speed of rendering.
* Added a bunch of explanatory info to the trend.h and communication.h